### PR TITLE
Update PSAction1.psm1 to use basic parsing

### DIFF
--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -25,6 +25,7 @@ $Script:Action1_BaseURI = ''
 $Script:Action1_Default_Org
 $Script:Action1_DebugEnabled = $false
 $Script:Action1_Interactive = $false
+$PSDefaultParameterValues['*:UseBasicParsing'] = $true
 
 $URILookUp = @{
     G_AdvancedSettings     = { param($Org_ID) "/setting_templates/$Org_ID" }


### PR DESCRIPTION
Basic parsing removes the need for internet explorer to be installed or first run setup to be completed. The only difference is the lack of DOM parsing which is not in use.
Resolves #4 