### PR TITLE
Add signature validation and PS files checking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 variables:
-- group: PSACTION1_SIGNATURE
+  - group: PSACTION1_SIGNATURE
 
 resources:
   repositories:
@@ -15,66 +15,110 @@ pool:
   vmImage: 'windows-latest'
 
 jobs:
-- job: SignScripts
-  displayName: 'Sign scripts'
-  steps:
+  - job: SignScripts
+    displayName: 'Sign scripts'
+    steps:
 
-    - checkout: self
-      clean: true
-      fetchDepth: 0
-      persistCredentials: true
+      - checkout: self
+        clean: true
+        fetchDepth: 0
+        persistCredentials: true
 
-    - task: PowerShell@2
-      displayName: 'Prepare PowerShell Files to Sign'
-      inputs:
-        targetType: inline
-        script: |
-          Get-ChildItem -Path "$(Build.SourcesDirectory)" -Recurse -Include *.ps1, *.psm1, *.psd1 -File |
-            ForEach-Object {
-                  $filePath = "$($_.FullName)"
-                  $fileBaseName = (Get-Item $filePath).BaseName
-                  $fileExtension = (Get-Item $filePath).Extension
-                  $signedFilePath = Join-Path -Path "$(Build.ArtifactStagingDirectory)" -ChildPath "$fileBaseName$fileExtension"
-                  Copy-Item -Path $filePath -Destination $signedFilePath
+      - task: PowerShell@2
+        name: PrepareAndCheckPS
+        displayName: "Prepare and check PowerShell files"
+        inputs:
+          targetType: inline
+          script: |
+            $sourceDir = "$(Build.SourcesDirectory)"
+            $stagingDir = "$(Build.ArtifactStagingDirectory)"
+
+            $files = Get-ChildItem -Path $sourceDir -Recurse -Include *.ps1, *.psm1, *.psd1 -File
+
+            if ($files.Count -eq 0) {
+              Write-Error "##[warning]No PowerShell files found to sign. Stopping pipeline."
+              throw "No PowerShell files found to sign."
+            }
+            else {
+              Write-Host "Found $($files.Count) PowerShell files. Preparing..."
+                foreach ($file in $files) {
+                  $fileBaseName = $file.BaseName
+                  $fileExtension = $file.Extension
+                  $signedFilePath = Join-Path -Path $stagingDir -ChildPath "$fileBaseName$fileExtension"
+                  Copy-Item -Path $file.FullName -Destination $signedFilePath -Force
+                }
+              Write-Host "##vso[task.setvariable variable=PSExists;isOutput=true]true"
             }
 
-    - task: AzureCLI@2
-      displayName: 'Prepare Azure Secure Connection'
-      inputs:
-        azureSubscription: 'Action1 Azure'
-        scriptType: 'pscore'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID]$env:servicePrincipalId"
-          Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID]$env:tenantId"
-          Write-Host "##vso[task.setvariable variable=ARM_ID_TOKEN]$env:idToken"
-        addSpnToEnvironment: true
+      - task: AzureCLI@2
+        displayName: "Prepare Azure Secure Connection"
+        inputs:
+          azureSubscription: "Action1 Azure"
+          scriptType: "pscore"
+          scriptLocation: "inlineScript"
+          inlineScript: |
+            Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID]$env:servicePrincipalId"
+            Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID]$env:tenantId"
+            Write-Host "##vso[task.setvariable variable=ARM_ID_TOKEN]$env:idToken"
+          addSpnToEnvironment: true
 
-    - task: PowerShell@2
-      displayName: 'Establish Azure Secure Connection'
-      inputs:
-        targetType: 'inline'
-        script: |
-          az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
+      - task: PowerShell@2
+        displayName: "Establish Azure Secure Connection"
+        inputs:
+          targetType: "inline"
+          script: |
+            az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
 
-    - task: TrustedSigning@0
-      displayName: 'Azure Trusted Signing'
-      inputs:
-        ExcludeSharedTokenCacheCredential: true
-        ExcludeVisualStudioCredential: true
-        ExcludeVisualStudioCodeCredential: true
-        Endpoint: '$(AZURE_TS_ENDPOINT)'
-        CertificateProfileName: '$(AZURE_TS_CERTIFICATE_PROFILE_NAME)'
-        FilesFolder: '$(Build.ArtifactStagingDirectory)'
-        FilesFolderFilter: 'psm1,psd1,ps1'
-        FilesFolderRecurse: true
-        FileDigest: 'SHA256'
-        CodeSigningAccountName: '$(AZURE_TS_ACCOUNT_NAME)'
+      - task: TrustedSigning@0
+        displayName: "Azure Trusted Signing PS files"
+        condition: eq(variables['PrepareAndCheckPS.PSExists'], 'true')
+        inputs:
+          ExcludeSharedTokenCacheCredential: true
+          ExcludeVisualStudioCredential: true
+          ExcludeVisualStudioCodeCredential: true
+          Endpoint: "$(AZURE_TS_ENDPOINT)"
+          CertificateProfileName: "$(AZURE_TS_CERTIFICATE_PROFILE_NAME)"
+          FilesFolder: "$(Build.ArtifactStagingDirectory)"
+          FilesFolderFilter: "ps1,psm1,psd1"
+          FilesFolderRecurse: true
+          FileDigest: "SHA256"
+          TrustedSigningAccountName: "$(AZURE_TS_ACCOUNT_NAME)"
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Internally'
-      condition: always()
-      inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-        ArtifactName: 'release'
-        publishLocation: 'Container'
+      - task: PowerShell@2
+        displayName: "Validate PS module files Authenticode signatures"
+        inputs:
+          targetType: "inline"
+          script: |
+            $files = Get-ChildItem "$(Build.ArtifactStagingDirectory)" -Recurse -Include *.ps1,*.psm1,*.psd1
+
+            if (-not $files) {
+              Write-Error "No PowerShell files found for signature validation."
+            }
+
+            $failed = $false
+
+            foreach ($file in $files) {
+              $sig = Get-AuthenticodeSignature $file.FullName
+
+              Write-Host "Checking $($file.FullName) - Status: $($sig.Status)"
+
+              if ($sig.Status -ne 'Valid') {
+                Write-Error "Invalid signature: $($file.FullName)"
+                $failed = $true
+              }
+            }
+
+            if ($failed) {
+              Write-Error "##[warning]Signature validation failed. Stopping pipeline."
+              throw "Signature validation failed."
+            }
+
+            Write-Host "All PowerShell files are properly signed."
+
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish Internally"
+        condition: always()
+        inputs:
+          PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+          ArtifactName: "release"
+          publishLocation: "Container"


### PR DESCRIPTION
In scope of the [PSModule signing issue](https://dev.azure.com/Action1Corp/SupportDev/_boards/board/t/SupportDev%20Team/Backlog%20items?workitem=24544) investigation i added the following changes to the Azure DevOps pipeline:

1. Add PS file checking before signing
2. Add signature validation after singing
3. Update oudated parameter CodeSigningAccountName to TrustedSigningAccountName in the task: TrustedSigning@0

Successful Pipeline run from the branch: buildId=5999
