### PR TITLE
Fix/24725 add Australia locale to Set-Action1Locale function

### DIFF
--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -363,12 +363,13 @@ function Set-Action1DefaultOrg {
 }
 
 function Set-Action1Locale {
+    [Obsolete("This function is deprecated. Use Set-Action1Region instead.")]
     param (
         [Parameter(Mandatory)]
-        [ValidateSet('NorthAmerica', 'Europe')]
+        [ValidateSet('NorthAmerica', 'Europe', 'Australia')]
         [String]$Region
     )
-    Write-Host "Locale set, Note:Set-Action1Locale is being depreciated, please modify all scripts to use Set-Action1Region instead." -ForegroundColor Red
+    Write-Warning "Locale set, Note:Set-Action1Locale is being depreciated, please modify all scripts to use Set-Action1Region instead."
     Set-Action1Region -Region $Region
 }
 

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -20,7 +20,11 @@
 $Script:Action1_APIKey
 $Script:Action1_Secret
 $Script:Action1_Token
-$script:Action1_Hosts = [ordered]@{'North America' = 'https://app.action1.com/api/3.0'; Europe = 'https://app.eu.action1.com/api/3.0'; Australia = 'https://app.au.action1.com/api/3.0' }
+$script:Action1_Hosts = [ordered]@{
+    NorthAmerica = 'https://app.action1.com/api/3.0'; 
+    Europe = 'https://app.eu.action1.com/api/3.0'; 
+    Australia = 'https://app.au.action1.com/api/3.0'
+}
 $Script:Action1_BaseURI = ''
 $Script:Action1_Default_Org
 $Script:Action1_DebugEnabled = $false
@@ -379,11 +383,7 @@ function Set-Action1Region {
         [ValidateSet('NorthAmerica', 'Europe', 'Australia')]
         [String]$Region
     )
-    switch ($Region) {
-        NorthAmerica { $Script:Action1_BaseURI = "https://app.action1.com/api/3.0" }
-        Europe { $Script:Action1_BaseURI = "https://app.eu.action1.com/api/3.0" }
-        Australia { $Script:Action1_BaseURI = 'https://app.au.action1.com/api/3.0' }
-    }
+    $Script:Action1_BaseURI = $Script:Action1_Hosts[$Region]
 }
 
 function Set-Action1Interactive {

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -367,13 +367,12 @@ function Set-Action1DefaultOrg {
 }
 
 function Set-Action1Locale {
-    [Obsolete("This function is deprecated. Use Set-Action1Region instead.")]
+    [Obsolete("Please use Set-Action1Region instead.")]
     param (
         [Parameter(Mandatory)]
         [ValidateSet('NorthAmerica', 'Europe', 'Australia')]
         [String]$Region
     )
-    Write-Warning "Locale set, Note:Set-Action1Locale is being depreciated, please modify all scripts to use Set-Action1Region instead."
     Set-Action1Region -Region $Region
 }
 


### PR DESCRIPTION
Ticket: 24725
1. Add Australia locale to Set-Action1Locale function for consistency with Set-Action1Region function
2. Mark Set-Action1Locale  as obsolete
3. Remove API url storage duplication

Verification script:

```powershell
$script:Action1_Hosts = [ordered]@{
    NorthAmerica = 'https://app.action1.com/api/3.0'; 
    Europe = 'https://app.eu.action1.com/api/3.0'; 
    Australia = 'https://app.au.action1.com/api/3.0'
}

function Set-Action1Locale {
    [Obsolete("Please use Set-Action1Region instead.")]
    param (
        [Parameter(Mandatory)]
        [ValidateSet('NorthAmerica', 'Europe', 'Australia')]
        [String]$Region
    )
    Set-Action1Region -Region $Region
}

function Set-Action1Region {
    param (
        [Parameter(Mandatory)]
        [ValidateSet('NorthAmerica', 'Europe', 'Australia')]
        [String]$Region
    )
    $Script:Action1_BaseURI = $Script:Action1_Hosts[$Region]
}

Set-Action1Locale australia


$Script:Action1_BaseURI
```