### PR TITLE
Introduce solid Invoke-Action1ApiRequest function to handle 429 HTTP code

### DIFF
--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -143,17 +143,17 @@ function Initialize-Action1Token {
         ($null -ne $Script:Action1_Token.access_token) -and
         ($Script:Action1_Token.expires_at -ge (Get-Date))
     ) {
-        Write-Debug "Current token is valid."
+        Debug-Host "Current token is valid."
         return $true
     }
 
-    Write-Debug "Token not set or expired, fetching new token."
+    Debug-Host "Token not set or expired, fetching new token."
 
     $token = Request-Action1Token
 
     if ($null -ne $token) {
         $Script:Action1_Token = $token
-        Write-Debug "Token refresh successful."
+        Debug-Host "Token refresh successful."
         return $true
     }
 
@@ -284,7 +284,7 @@ function Invoke-Action1ApiRequest {
         }
     }
 
-    Write-Debug "$Method request to $Path. Raw flag is $Raw"
+    Debug-Host "$Method request to $Path. Raw flag is $Raw"
 
     $invokeWebRequestParams = @{
         Uri             = $Path
@@ -316,7 +316,7 @@ function Invoke-Action1ApiRequest {
                 return ConvertFrom-Json -InputObject $response.Content
             }
 
-            Write-Error "Error processing $($Label): HTTP status code $($response.StatusCode)."
+            Debug-Host "Error processing $($Label): HTTP status code $($response.StatusCode)."
             return $null
         }
         catch {
@@ -336,12 +336,12 @@ function Invoke-Action1ApiRequest {
                     $retryTimeout = $Script:Action1_429RetryTimeOutLevel2
                 }
 
-                Write-Debug ("429 received for '{0}'. Retry #{1}. Sleeping {2} ms." -f $Label, $retry429Count, $retryTimeout)
+                Debug-Host ("429 received for '{0}'. Retry #{1}. Sleeping {2} ms." -f $Label, $retry429Count, $retryTimeout)
                 Start-Sleep -Milliseconds $retryTimeout
                 continue
             }
 
-            Write-Error "Error processing $($Label): $($_.Exception.Message)"
+            Debug-Host "Error processing $($Label): $($_.Exception.Message)"
             return $null
         }
     }

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -284,7 +284,7 @@ function Invoke-Action1ApiRequest {
         }
     }
 
-    Debug-Host "$Method request to $Path. Raw flag is $RawResponse"
+    Debug-Host "$Method request to $Path. RawResponse flag is $RawResponse"
 
     $invokeWebRequestParams = @{
         Uri             = $Path

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -25,8 +25,7 @@ $Script:Action1_DebugEnabled = $false
 $Script:Action1_Interactive = $false
 $Script:Action1_CVE_Lookup = @{}
 
-$Script:Action1_429RetryTimeoutLevel1 = 1100
-$Script:Action1_429RetryTimeOutLevel2 = 60100
+$Script:Action1_429RetryBaseTimeout = 2000
 
 $URILookUp = @{
     G_AdvancedSettings     = { param($Org_ID) "/setting_templates/$Org_ID" }
@@ -333,14 +332,9 @@ function Invoke-Action1ApiRequest {
             Debug-Host ("Failed response code {0} for {1} to {2}" -f $statusCode, $Method, $Path)
 
             if ($statusCode -eq 429) {
+                
+                $retryTimeout = [Math]::Pow(2,$retry429Count) * $Script:Action1_429RetryBaseTimeout
                 $retry429Count++
-
-                if ($retry429Count -eq 1) {
-                    $retryTimeout = $Script:Action1_429RetryTimeoutLevel1
-                }
-                else {
-                    $retryTimeout = $Script:Action1_429RetryTimeOutLevel2
-                }
 
                 Debug-Host ("429 received for '{0}'. Retry #{1}. Sleeping {2} ms." -f $Label, $retry429Count, $retryTimeout)
                 Start-Sleep -Milliseconds $retryTimeout

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -275,16 +275,14 @@ function Invoke-Action1ApiRequest {
 
     if ($PSBoundParameters.ContainsKey('Body') -and $null -ne $Body) {
         if ($RawBody) {
-            Debug-Host "Raw request body supplied. Type: $($requestBody.GetType().FullName)"
             $requestBody = $Body
+            Debug-Host "Raw request body supplied. Type: $($requestBody.GetType().FullName)"
         }
         else {
-            Debug-Host "JSON Data to be sent:`n$requestBody"
             $requestBody = ConvertTo-Json -InputObject $Body -Depth 10
+            Debug-Host "JSON Data to be sent:`n$requestBody"  
         }
     }
-
-    Debug-Host "$Method request to $Path. RawResponse flag is $RawResponse"
 
     $invokeWebRequestParams = @{
         Uri             = $Path
@@ -301,10 +299,16 @@ function Invoke-Action1ApiRequest {
     $retry429Count = 0
 
     while ($true) {
+        Debug-Host "$Method request to $Path. RawResponse flag is $RawResponse"
         try {
+            $webRequestSW = [System.Diagnostics.Stopwatch]::StartNew()
             $response = Invoke-WebRequest @invokeWebRequestParams
+            $webRequestSW.Stop()
+
+            Debug-Host ("{2} request to {0} took {1}ms" -f $Path, $($webRequestSW.ElapsedMilliseconds), $Method)
 
             if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                Debug-Host ("Success response code {0} for {1} to {2}" -f $($response.StatusCode), $Method, $Path)
                 if ($RawResponse) {
                     return $response.Content
                 }
@@ -326,10 +330,12 @@ function Invoke-Action1ApiRequest {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
+            Debug-Host ("Failed response code {0} for {1} to {2}" -f $statusCode, $Method, $Path)
+
             if ($statusCode -eq 429) {
                 $retry429Count++
 
-                if ($retry429Count % 2 -eq 1) {
+                if ($retry429Count -eq 1) {
                     $retryTimeout = $Script:Action1_429RetryTimeoutLevel1
                 }
                 else {

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -137,22 +137,28 @@ $PackageDeployTemplate = @"
 "@
 #----------------------------------JSON object templates---------------------------------------
 
-function CheckToken() {
-    if (($null -ne $Script:Action1_Token) -and ($null -ne $Script:Action1_Token.access_token) -and ($Script:Action1_Token.expires_at -ge $(Get-Date))) {
+function Initialize-Action1Token {
+    if (
+        ($null -ne $Script:Action1_Token) -and
+        ($null -ne $Script:Action1_Token.access_token) -and
+        ($Script:Action1_Token.expires_at -ge (Get-Date))
+    ) {
         Write-Debug "Current token is valid."
         return $true
     }
-    else {
-        Write-Debug "Token not set or expired, fetching new token."
-        if (FetchToken -ne $null ) {
-            Write-Debug "Token refresh successful."
-            return $true
-        }
-        else {
-            Write-Error "Token could not be refreshed, check for errors in output."
-            return $false
-        }
+
+    Write-Debug "Token not set or expired, fetching new token."
+
+    $token = Request-Action1Token
+
+    if ($null -ne $token) {
+        $Script:Action1_Token = $token
+        Write-Debug "Token refresh successful."
+        return $true
     }
+
+    Write-Error "Token could not be refreshed, check for errors in output."
+    return $false
 }
 
 function CheckRoot {
@@ -174,6 +180,7 @@ function CheckRoot {
     }
     return $true
 }
+
 function CheckOrg {
     if ($null -eq $Script:Action1_Default_Org) {
         if ($Script:Action1_Interactive) {
@@ -186,7 +193,8 @@ function CheckOrg {
     }
     return $Script:Action1_Default_Org 
 }
-function FetchToken {
+
+function Request-Action1Token {
     if (CheckRoot) {
         if ([string]::IsNullOrEmpty($Script:Action1_APIKey) -or [string]::IsNullOrEmpty($Script:Action1_Secret)) {
             if ($Script:Action1_Interactive) {
@@ -208,7 +216,6 @@ function FetchToken {
                 } `
                 -SkipAuthenticationCheck
             $Token | Add-Member -MemberType NoteProperty -Name "expires_at" -Value $(Get-Date).AddSeconds(([int]$Token.expires_in - 5)) #Expire token 5 seconds early to avoid race condition timeouts.
-            $Script:Action1_Token = $Token
             return $Token
         }
         catch [System.Net.WebException] {
@@ -251,7 +258,7 @@ function Invoke-Action1ApiRequest {
     $headers = @{}
 
     if (-not $SkipAuthenticationCheck) {
-        if (CheckToken) {
+        if (Initialize-Action1Token) {
             $headers.Authorization = "Bearer $($Script:Action1_Token.access_token)"
         }
     }
@@ -373,11 +380,7 @@ function Start-Action1PackageUpload {
     try {
         $Headers = $HeaderBase.Clone()
         $Headers.Add('X-Upload-Content-Length', $($FileData.Length))
-        $Headers.Add('Content-Type', 'application/json')
-        if (CheckToken) { 
-            $Headers.Add('Authorization', "Bearer $(($Script:Action1_Token).access_token)")
-            Invoke-Action1ApiRequest -Method POST -Path $uri -Label 'Opening upload stream' -Headers $Headers -ErrorAction SilentlyContinue  
-        }
+        Invoke-Action1ApiRequest -Method POST -Path $uri -Label 'Opening upload stream' -Headers $Headers -ErrorAction SilentlyContinue  
     }
     catch { 
         $UploadTarget = $_.Exception.Response.Headers['X-Upload-Location'] 
@@ -392,17 +395,14 @@ function Start-Action1PackageUpload {
         $Headers.Add('Content-Type', 'application/octet-stream')
         $Place += $Read
         try { 
-            if (CheckToken) { 
-                $Headers.Add('Authorization', "Bearer $(($Script:Action1_Token).access_token)")
-                $response = Invoke-Action1ApiRequest `
-                    -Method PUT `
-                    -Path $UploadTarget `
-                    -Label "Uploading Package $($Package_ID)" `
-                    -Body $Buffer `
-                    -RawBody `
-                    -Headers $Headers `
-                    -ErrorAction SilentlyContinue
-            } 
+            $response = Invoke-Action1ApiRequest `
+                -Method PUT `
+                -Path $UploadTarget `
+                -Label "Uploading Package $($Package_ID)" `
+                -Body $Buffer `
+                -RawBody `
+                -Headers $Headers `
+                -ErrorAction SilentlyContinue         
         }
         catch {
             Debug-Host "Last Status: $($_.Exception.Response.StatusCode)" 
@@ -542,7 +542,15 @@ function Get-Action1 {
         [string]$Clone
     )
     #Short out processing path if URI literal is specified.
-    if ($Query -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Query is type RawURI.`n"; return $null }else { return Invoke-Action1ApiRequest -Method GET -Path $URI -Label $Query } }
+    if ($Query -eq 'RawURI') {
+         if (!$URI) {
+             Write-Error "Error -URI value required when Query is type RawURI.`n"; 
+             return $null 
+        }
+        else {
+             return Invoke-Action1ApiRequest -Method GET -Path $URI -Label $Query 
+        } 
+    }
     # Retrieve settings objects for post/patch actions.
     if ($Query -eq 'Settings') {
         if (!$For) { 
@@ -760,7 +768,12 @@ function Get-Action1 {
             $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg))
         }
     } 
-    if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs }
+    if ($Rawlist.Contains($Query)) {
+         $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -Raw 
+    } 
+    else {
+         $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs 
+    }
     if ($Page.items) {
         switch -Wildcard ($Query) {
             'PolicyResults' {
@@ -829,22 +842,29 @@ function New-Action1 {
     )
         Debug-Host "Creating new $Item."
     #Short out processing path if URI literal is specified.
-    if ($Item -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Action is type RawURI.`n"; return $null }else { if (CheckToken) { return Invoke-Action1ApiRequest -Method POST -Path $URI -Body $Data -Label 'RawRequest'} } }
-    if (CheckToken) {
-        try {
-            if (!$URILookUp["N_$Item"].ToString().Contains("`$Org_ID")) {
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"])
-            }
-            else {
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"] -Org_ID $(CheckOrg))
-            } 
-            return Invoke-Action1ApiRequest -Method POST -Path $Path -Label $Item -Body $Data
+    if ($Item -eq 'RawURI') {
+         if (!$URI) {
+             Write-Error "Error -URI value required when Action is type RawURI.`n"; 
+             return $null 
         }
-        catch {
-            Write-Error "Error adding $Item`: $($_)."
-            return $null
-        }
+        else { 
+            return Invoke-Action1ApiRequest -Method POST -Path $URI -Body $Data -Label 'RawRequest'
+        } 
     }
+    try {
+        if (!$URILookUp["N_$Item"].ToString().Contains("`$Org_ID")) {
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"])
+        }
+        else {
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"] -Org_ID $(CheckOrg))
+        } 
+        return Invoke-Action1ApiRequest -Method POST -Path $Path -Label $Item -Body $Data
+    }
+    catch {
+        Write-Error "Error adding $Item`: $($_)."
+        return $null
+    }
+    
 }
 
 function Update-Action1 {
@@ -874,68 +894,74 @@ function Update-Action1 {
     )
     Debug-Host "Trying update for $Action => $Type."
     #Short out processing path if URI literal is specified.
-    if ($Type -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Action is type RawURI.`n"; return $null }else { if (CheckToken) { return Invoke-Action1ApiRequest -Method PATCH -Path $URI -Body $Data -Label 'RawRequest'} } }
-    if (CheckToken) {
-        switch ($Action) {
-            'ModifyMembers' {
-                switch ($Type) {
-                    'EndpointGroup' { 
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupMembers"] -Org_ID $(CheckOrg) -Object_ID $id)
-                        return Invoke-Action1ApiRequest -Method POST -Path $Path -Body $Data -Label "$Action=>$Type"
-                    }
-                    default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
-                }
-            }
-            'Modify' {              
-                if (!$Id) { Write-Error "When perfoming $Action=>$Type, the value for -Id must be specified to know what object to act on."; return $null } 
-                switch ($Type) {
-                    'Automation' {
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
-                    }
-                    'CustomAttribute' {
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                        $Data = New-Object psobject -Property @{"custom:$AttributeName" = $AttributeValue }
-                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
-                    }
-                    'Endpoint' { 
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                        $Data.PSObject.Members | ForEach-Object { if (@('name', 'comment') -notcontains $_.Name) { $Data.PSObject.Members.Remove($_.Name) } }
-                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
-                    }
-                    'EndpointGroup' { 
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type"
-                    }
-                    default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
-                }   
-            }
-            'Delete' {
-                Debug-Host "Force delete enabled:$Force."
-                switch ($Type) {
-                    'EndpointGroup' { 
-                        if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
-                            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                            return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
-                        }
-                    }
-                    'Endpoint' { 
-                        if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
-                            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                            return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
-                        }
-                    }
-                    'Automation' {
-                        if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
-                            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                            return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
-                        }
-                    }
-                    default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
-                }
-            }
-            default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
+    if ($Type -eq 'RawURI') {
+        if (!$URI) {
+             Write-Error "Error -URI value required when Action is type RawURI.`n"; 
+             return $null 
         }
+        else {
+            return Invoke-Action1ApiRequest -Method PATCH -Path $URI -Body $Data -Label 'RawRequest' 
+        } 
+    }
+    switch ($Action) {
+        'ModifyMembers' {
+            switch ($Type) {
+                'EndpointGroup' { 
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupMembers"] -Org_ID $(CheckOrg) -Object_ID $id)
+                    return Invoke-Action1ApiRequest -Method POST -Path $Path -Body $Data -Label "$Action=>$Type"
+                }
+                default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
+            }
+        }
+        'Modify' {              
+            if (!$Id) { Write-Error "When perfoming $Action=>$Type, the value for -Id must be specified to know what object to act on."; return $null } 
+            switch ($Type) {
+                'Automation' {
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
+                }
+                'CustomAttribute' {
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    $Data = New-Object psobject -Property @{"custom:$AttributeName" = $AttributeValue }
+                    return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
+                }
+                'Endpoint' { 
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    $Data.PSObject.Members | ForEach-Object { if (@('name', 'comment') -notcontains $_.Name) { $Data.PSObject.Members.Remove($_.Name) } }
+                    return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
+                }
+                'EndpointGroup' { 
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type"
+                }
+                default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
+            }   
+        }
+        'Delete' {
+            Debug-Host "Force delete enabled:$Force."
+            switch ($Type) {
+                'EndpointGroup' { 
+                    if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
+                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                        return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
+                    }
+                }
+                'Endpoint' { 
+                    if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
+                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                        return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
+                    }
+                }
+                'Automation' {
+                    if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
+                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                        return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
+                    }
+                }
+                default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
+            }
+        }
+        default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
     }
 }
 
@@ -950,25 +976,24 @@ function Start-Action1Requery {
         [string]$Type,
         [string]$Endpoint_Id                    
     )
-    if (CheckToken) {
-        if (!$URILookUp["R_$Type"].ToString().Contains("`$Org_ID")) {
-            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"])
-        }
-        else {
-            if ($Endpoint_Id) {
-                if ($URILookUp["R_$Type"].ToString().Contains("`$Object_ID")) {
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg) -Object_ID $Endpoint_Id)
-                }
-                else {
-                    Write-Error "Endpoint_Id was specified but this action is not endpoint specific, can continue, defaulting to system wide."
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg))
-                } 
+    if (!$URILookUp["R_$Type"].ToString().Contains("`$Org_ID")) {
+        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"])
+    }
+    else {
+        if ($Endpoint_Id) {
+            if ($URILookUp["R_$Type"].ToString().Contains("`$Object_ID")) {
+                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg) -Object_ID $Endpoint_Id)
             }
             else {
+                Write-Error "Endpoint_Id was specified but this action is not endpoint specific, can continue, defaulting to system wide."
                 $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg))
-            }
-        } 
-        return Invoke-Action1ApiRequest -Method POST -Path $Path.TrimEnd('/') -Label "Requery=>$Type"
-    }
+            } 
+        }
+        else {
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg))
+        }
+    } 
+
+    return Invoke-Action1ApiRequest -Method POST -Path $Path.TrimEnd('/') -Label "Requery=>$Type"  
 }
 

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -25,6 +25,9 @@ $Script:Action1_DebugEnabled = $false
 $Script:Action1_Interactive = $false
 $Script:Action1_CVE_Lookup = @{}
 
+$Script:Action1_429RetryTimeoutLevel1 = 1100
+$Script:Action1_429RetryTimeOutLevel2 = 60100
+
 $URILookUp = @{
     G_AdvancedSettings     = { param($Org_ID) "/setting_templates/$Org_ID" }
     G_AgentDeployment      = { param($Org_ID) "/endpoints/discovery/$Org_ID" }
@@ -195,7 +198,14 @@ function FetchToken {
             } 
         }
         try {
-            $Token = (ConvertFrom-Json -InputObject (Invoke-WebRequest -Uri "$Script:Action1_BaseURI/oauth2/token" -Method POST -UseBasicParsing -Body @{client_id = $Script:Action1_APIKey; client_secret = $Script:Action1_Secret }).Content )  
+            $Token = Invoke-Action1ApiRequest `
+                -Method POST `
+                -Path "$Script:Action1_BaseURI/oauth2/token" `
+                -Label 'Request OAuth2 token' `
+                -Body @{
+                    client_id     = $Script:Action1_APIKey
+                    client_secret = $Script:Action1_Secret
+                } 
             $Token | Add-Member -MemberType NoteProperty -Name "expires_at" -Value $(Get-Date).AddSeconds(([int]$Token.expires_in - 5)) #Expire token 5 seconds early to avoid race condition timeouts.
             $Script:Action1_Token = $Token
             return $Token
@@ -216,29 +226,123 @@ function BuildArgs {
     if ([string]::IsNullOrEmpty($In)) { return $Add }else { return "$In&$Add" }
 }
 
-function DoGet {
+function Invoke-Action1ApiRequest {
+	[CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [String]$Path,
+        [ValidateSet(
+            'GET',
+            'POST',
+            'PUT',
+            'PATCH',
+            'DELETE'
+        )]
+        [string]$Method,
         [Parameter(Mandatory)]
-        [String]$Label,
-        [String]$AddArgs,
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Label,
+        [hashtable]$Headers,
+        [object]$Body,
+        [switch]$RawBody,
+        [string]$AddArgs,
         [switch]$Raw
     )
-    try {
-        if ($AddArgs) { $Path += "?{0}" -f $AddArgs }
-        Debug-Host "GET request to $Path : Raw flag is $Raw"
-        if ($Raw) {
-            return (Invoke-WebRequest -Uri $Path -Method GET -UseBasicParsing -Headers @{Authorization = "Bearer $(($Script:Action1_Token).access_token)"; 'Content-Type' = 'application/json; charset=utf-8' }).Content
-        }
-        else { 
-            return (ConvertFrom-Json -InputObject (Invoke-WebRequest -Uri $Path -Method GET -UseBasicParsing -Headers @{Authorization = "Bearer $(($Script:Action1_Token).access_token)"; 'Content-Type' = 'application/json; charset=utf-8' }).Content ) 
-        } 
+
+    if ($AddArgs) {
+        $Path += "?{0}" -f $AddArgs
     }
-    catch [System.Net.WebException] {
-        Write-Error "Error fetching $($Label): $($_)."
-        return $null
-    } 
+
+    $headers = @{
+        Authorization  = "Bearer $(($Script:Action1_Token).access_token)"
+        'Content-Type' = 'application/json; charset=utf-8'
+    }
+
+    if ($Headers) {
+        foreach ($key in $Headers.Keys) {
+            $headers[$key] = $Headers[$key]
+        }
+    }
+
+    $requestBody = $null
+
+    if ($PSBoundParameters.ContainsKey('Body') -and $null -ne $Body) {
+        if ($RawBody) {
+            $requestBody = $Body
+        }
+        else {
+            $requestBody = ConvertTo-Json -InputObject $Body -Depth 10
+        }
+    }
+
+    Debug-Host "$Method request to $Path. Raw flag is $Raw"
+
+    $invokeWebRequestParams = @{
+        Uri             = $Path
+        Method          = $Method
+        UseBasicParsing = $true
+        Headers         = $headers
+    }
+
+    if ($null -ne $requestBody) {
+        $invokeWebRequestParams.Body = $requestBody
+
+        if ($RawBody) {
+            Debug-Host "Raw request body supplied. Type: $($requestBody.GetType().FullName)"
+        }
+        else {
+            Debug-Host "JSON Data to be sent:`n$requestBody"
+        }
+    }
+
+    $retry429Count = 0
+
+    while ($true) {
+        try {
+            $response = Invoke-WebRequest @invokeWebRequestParams
+
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+
+                if ($Raw) {
+                    return $response.Content
+                }
+
+                if ([string]::IsNullOrWhiteSpace($response.Content)) {
+                    return $null
+                }
+
+                return ConvertFrom-Json -InputObject $response.Content
+            }
+
+            Write-Error "Error processing $($Label): HTTP status code $($response.StatusCode)."
+            return $null
+        }
+        catch [System.Net.WebException] {
+
+            $httpResponse = $_.Exception.Response
+
+            if ($httpResponse -and ([int]$httpResponse.StatusCode -eq 429)) {
+
+                $retry429Count++
+
+                if ($retry429Count % 2 -eq 1) {
+                    $retryTimeout = $Script:Action1_429RetryTimeoutLevel1
+                }
+                else {
+                    $retryTimeout = $Script:Action1_429RetryTimeOutLevel2
+                }
+
+                Debug-Host "HTTP 429 received for $Label. Waiting $retryTimeout ms before retry."
+
+                Start-Sleep -Milliseconds $retryTimeout
+
+                continue
+            }
+
+            Write-Error "Error processing $($Label): $($_)"
+            return $null
+        }
+    }
 }
 
 function Start-Action1PackageUpload {
@@ -275,21 +379,49 @@ function Start-Action1PackageUpload {
         $Headers = $HeaderBase.Clone()
         $Headers.Add('X-Upload-Content-Length', $($FileData.Length))
         $Headers.Add('Content-Type', 'application/json')
-        if (CheckToken) { $Headers.Add('Authorization', "Bearer $(($Script:Action1_Token).access_token)"); Invoke-WebRequest -Uri $uri -Method Post -UseBasicParsing -Headers $Headers -ErrorAction SilentlyContinue }
+        if (CheckToken) { 
+            $Headers.Add('Authorization', "Bearer $(($Script:Action1_Token).access_token)")
+            Invoke-Action1ApiRequest -Method POST -Path $uri -Label 'Opening upload stream' -Headers $Headers -ErrorAction SilentlyContinue  
+        }
     }
-    catch { $UploadTarget = $_.Exception.Response.Headers['X-Upload-Location'] } 
+    catch { 
+        $UploadTarget = $_.Exception.Response.Headers['X-Upload-Location'] 
+    } 
+
     Debug-Host "Upload URI is $UploadTarget"
+
     while (($Read = $FileData.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
         $Headers = $HeaderBase.Clone()
         $Headers.Add('Content-Range', "bytes $($Place)-$($($Place + $Read-1))/$($FileData.Length)")
         $Headers.Add('Content-Length', "$($Read)")
         $Headers.Add('Content-Type', 'application/octet-stream')
         $Place += $Read
-        try { if (CheckToken) { $Headers.Add('Authorization', "Bearer $(($Script:Action1_Token).access_token)"); $response = Invoke-WebRequest -Method Put -UseBasicParsing -Uri $UploadTarget -Body $Buffer -Headers $Headers -ErrorAction SilentlyContinue } }
-        catch { Debug-Host "Last Status: $($_.Exception.Response.StatusCode)" }
-        if (($FileData.Length - $Place) -lt $BufferSize) { $buffer = New-Object byte[] ($FileData.Length - $place) }
+        try { 
+            if (CheckToken) { 
+                $Headers.Add('Authorization', "Bearer $(($Script:Action1_Token).access_token)")
+                $response = Invoke-Action1ApiRequest `
+                    -Method PUT `
+                    -Path $UploadTarget `
+                    -Label "Uploading Package $($Package_ID)" `
+                    -Body $Buffer `
+                    -RawBody `
+                    -Headers $Headers `
+                    -ErrorAction SilentlyContinue
+            } 
+        }
+        catch {
+            Debug-Host "Last Status: $($_.Exception.Response.StatusCode)" 
+        }
+        if (($FileData.Length - $Place) -lt $BufferSize) { 
+            $buffer = New-Object byte[] ($FileData.Length - $place) 
+        }
         Debug-Host "Upload $([math]::Round((($Place / $FileData.Length)*100),1))% Complete."
-        if ($Buffer.Length -eq 0) { Debug-Host "Final Status:$($response.StatusCode)" }else { Debug-Host "Bytes Written: $($Buffer.Length)" }
+
+        if ($Buffer.Length -eq 0) { 
+            Debug-Host "Final Status:$($response.StatusCode)" 
+        }else {
+            Debug-Host "Bytes Written: $($Buffer.Length)" 
+        }
     }
     $FileData.Close()
 }
@@ -301,32 +433,6 @@ function Debug-Host {
         [string]$Message
     )
     if ($Script:Action1_DebugEnabled) { Write-Host "Action1 Debug: $Message" -ForegroundColor Blue }
-}
-
-function PushData {
-    param (
-        [Parameter(Mandatory)]
-        [ValidateSet(
-            'PATCH',
-            'POST',
-            'DELETE'
-        )]
-        [string]$Method,
-        [Parameter(Mandatory)]
-        [String]$Path,
-        [Parameter(Mandatory)]
-        [String]$Label,
-        [object]$Body
-    )
-    try {
-        Debug-Host "$Method request to $Path."
-        if ($data) { Debug-Host "Data to be sent:`n $(ConvertTo-Json -InputObject $Body -Depth 10)" }
-        return (ConvertFrom-Json -InputObject (Invoke-WebRequest -Uri $Path -Method $Method -UseBasicParsing -Body (ConvertTo-Json -InputObject $Body -Depth 10) -Headers @{Authorization = "Bearer $(($Script:Action1_Token).access_token)"; 'Content-Type' = 'application/json; charset=utf-8' }).Content)
-    }
-    catch [System.Net.WebException] {
-        Write-Error "Error processing $($Label): $($_)"
-        return $null
-    } 
 }
 
 function Set-Action1Credentials {
@@ -441,7 +547,7 @@ function Get-Action1 {
         [string]$Clone
     )
     #Short out processing path if URI literal is specified.
-    if ($Query -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Query is type RawURI.`n"; return $null }else { if (CheckToken) { return DoGet -Path $URI -Label $Query } } }
+    if ($Query -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Query is type RawURI.`n"; return $null }else { if (CheckToken) { return Invoke-Action1ApiRequest -Method GET -Path $URI -Label $Query } } }
     # Retrieve settings objects for post/patch actions.
     if ($Query -eq 'Settings') {
         if (!$For) { 
@@ -626,10 +732,10 @@ function Get-Action1 {
     if (CheckToken) {
         $AddArgs = ""
         $sbPolicyResultsDetail = {
-            $Page = DoGet -Path $this.details -Label "PolicyResultsDetails"
+            $Page = Invoke-Action1ApiRequest -Method GET -Path $this.details -Label 'PolicyResultsDetails'
             $Page.items | Write-Output
             While (![string]::IsNullOrEmpty($Page.next_page)) {
-                $Page = DoGet -Path $Page.next_page -Label "PolicyResultsDetails"
+                $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label 'PolicyResultsDetails'
                 $Page.items | Write-Output
             }
         }
@@ -660,7 +766,7 @@ function Get-Action1 {
                 $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg))
             }
         } 
-        if ($Rawlist.Contains($Query)) { $Page = DoGet -Path $Path -Label $Query -AddArgs $AddArgs -Raw } else { $Page = DoGet -Path $Path -Label $Query -AddArgs $AddArgs }
+        if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs }
         if ($Page.items) {
             switch -Wildcard ($Query) {
                 'PolicyResults' {
@@ -679,7 +785,7 @@ function Get-Action1 {
             }
             While (![string]::IsNullOrEmpty($Page.next_page)) {
                 Debug-Host "[$Query] Next page..."
-                if ($Rawlist.Contains($Query)) { $Page = DoGet -Path $Page.next_page -Label $Query -Raw } else { $Page = DoGet -Path $Page.next_page -Label $Query }
+                if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query }
                 switch -Wildcard ($Query) {
                     'PolicyResults' {
                         $page.Items | ForEach-Object {
@@ -729,7 +835,7 @@ function New-Action1 {
     )
         Debug-Host "Creating new $Item."
     #Short out processing path if URI literal is specified.
-    if ($Item -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Action is type RawURI.`n"; return $null }else { if (CheckToken) { return PushData -Path $URI -Method POST -Body $Data -Label 'RawRequest'} } }
+    if ($Item -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Action is type RawURI.`n"; return $null }else { if (CheckToken) { return Invoke-Action1ApiRequest -Method POST -Path $URI -Body $Data -Label 'RawRequest'} } }
     if (CheckToken) {
         try {
             if (!$URILookUp["N_$Item"].ToString().Contains("`$Org_ID")) {
@@ -738,7 +844,7 @@ function New-Action1 {
             else {
                 $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"] -Org_ID $(CheckOrg))
             } 
-            return PushData -Method POST -Path $Path -Label $Item -Body $Data
+            return Invoke-Action1ApiRequest -Method POST -Path $Path -Label $Item -Body $Data
         }
         catch {
             Write-Error "Error adding $Item`: $($_)."
@@ -774,14 +880,14 @@ function Update-Action1 {
     )
     Debug-Host "Trying update for $Action => $Type."
     #Short out processing path if URI literal is specified.
-    if ($Type -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Action is type RawURI.`n"; return $null }else { if (CheckToken) { return PushData -Path $URI -Method PATCH -Body $Data -Label 'RawRequest'} } }
+    if ($Type -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Action is type RawURI.`n"; return $null }else { if (CheckToken) { return Invoke-Action1ApiRequest -Method PATCH -Path $URI -Body $Data -Label 'RawRequest'} } }
     if (CheckToken) {
         switch ($Action) {
             'ModifyMembers' {
                 switch ($Type) {
                     'EndpointGroup' { 
                         $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupMembers"] -Org_ID $(CheckOrg) -Object_ID $id)
-                        return PushData -Method POST -Path $Path -Body $Data -Label "$Action=>$Type"
+                        return Invoke-Action1ApiRequest -Method POST -Path $Path -Body $Data -Label "$Action=>$Type"
                     }
                     default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
                 }
@@ -791,21 +897,21 @@ function Update-Action1 {
                 switch ($Type) {
                     'Automation' {
                         $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                        return PushData -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
+                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
                     }
                     'CustomAttribute' {
                         $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
                         $Data = New-Object psobject -Property @{"custom:$AttributeName" = $AttributeValue }
-                        return PushData -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
+                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
                     }
                     'Endpoint' { 
                         $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
                         $Data.PSObject.Members | ForEach-Object { if (@('name', 'comment') -notcontains $_.Name) { $Data.PSObject.Members.Remove($_.Name) } }
-                        return PushData -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
+                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
                     }
                     'EndpointGroup' { 
                         $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                        return PushData -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type"
+                        return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type"
                     }
                     default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
                 }   
@@ -816,19 +922,19 @@ function Update-Action1 {
                     'EndpointGroup' { 
                         if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
                             $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                            return PushData -Method DELETE -Path $Path -Label "$Action=>$Type"
+                            return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
                         }
                     }
                     'Endpoint' { 
                         if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
                             $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                            return PushData -Method DELETE -Path $Path -Label "$Action=>$Type"
+                            return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
                         }
                     }
                     'Automation' {
                         if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
                             $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
-                            return PushData -Method DELETE -Path $Path -Label "$Action=>$Type"
+                            return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
                         }
                     }
                     default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
@@ -868,7 +974,7 @@ function Start-Action1Requery {
                 $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg))
             }
         } 
-        return PushData -Method POST -Path $Path.TrimEnd('/') -Label "Requery=>$Type"
+        return Invoke-Action1ApiRequest -Method POST -Path $Path.TrimEnd('/') -Label "Requery=>$Type"
     }
 }
 

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -137,6 +137,9 @@ $PackageDeployTemplate = @"
 #----------------------------------JSON object templates---------------------------------------
 
 function Initialize-Action1Token {
+    [CmdletBinding()]
+    param()
+
     if (
         ($null -ne $Script:Action1_Token) -and
         ($null -ne $Script:Action1_Token.access_token) -and
@@ -160,41 +163,67 @@ function Initialize-Action1Token {
     return $false
 }
 
-function CheckRoot {
-    if ($Script:Action1_BaseURI -eq '') {
-        if ($Script:Action1_Interactive) {
-            while ($Script:Action1_BaseURI -eq '') {
-                0..($Action1_Hosts.Count - 1) | `
-                    ForEach-Object {
-                    Write-Host "$($_) : $($($Action1_Hosts.Keys -Split '`n')[$_])" }; 
-                $Script:Action1_BaseURI = $($Action1_Hosts.Values -Split '`n')[[int]::Parse($(Read-Host -Prompt 'Select your data center region.'))]
+function Initialize-Action1Region {
+    [CmdletBinding()]
+    param()
 
-            }
-            return $true
+    if (-not [string]::IsNullOrWhiteSpace($Script:Action1_BaseURI)) {
+        return $true
+    }
+
+    if (-not $Script:Action1_Interactive) {
+        throw "Region not set. Call Set-Action1Region prior to making API calls."
+    }
+
+    $regions = @($Script:Action1_Hosts.GetEnumerator())
+
+    while ([string]::IsNullOrWhiteSpace($Script:Action1_BaseURI)) {
+
+        for ($i = 0; $i -lt $regions.Count; $i++) {
+            Write-Host "$i : $($regions[$i].Key)"
+        }
+
+        $selection = Read-Host -Prompt 'Select your data center region'
+
+        $index = 0
+        if (
+            [int]::TryParse($selection, [ref]$index) -and
+            $index -ge 0 -and
+            $index -lt $regions.Count
+        ) {
+            $Script:Action1_BaseURI = $regions[$index].Value
         }
         else {
-            Write-Error "Region not set, call Set-Action1Region prior to making any calls to the API."
-            exit
+            Write-Warning "Invalid selection."
         }
     }
     return $true
 }
 
-function CheckOrg {
+function Initialize-Action1DefaultOrg {
+    [CmdletBinding()]
+    param()
+
     if ($null -eq $Script:Action1_Default_Org) {
         if ($Script:Action1_Interactive) {
-            while ($null -eq $Script:Action1_Default_Org) { Set-Action1DefaultOrg }
+            Set-Action1DefaultOrg
+
+            if ($null -eq $Script:Action1_Default_Org) {
+                throw "Default organization was not selected."
+            }
         }
         else {
-            Write-Error "Default Org not set, call Set-Action1DefaultOrg prior to making any calls to the API."
-            exit
+            throw "Default Org not set. Call Set-Action1DefaultOrg before making API calls."
         }
     }
-    return $Script:Action1_Default_Org 
+    return $Script:Action1_Default_Org
 }
 
 function Request-Action1Token {
-    if (CheckRoot) {
+    [CmdletBinding()]
+    param()
+
+    if (Initialize-Action1Region) {
         if ([string]::IsNullOrEmpty($Script:Action1_APIKey) -or [string]::IsNullOrEmpty($Script:Action1_Secret)) {
             if ($Script:Action1_Interactive) {
                 Set-Action1Credentials 
@@ -225,12 +254,18 @@ function Request-Action1Token {
     }
 }
 
-function BuildArgs {
-    param (
-        [String]$In,
-        [String]$Add
+function Join-QueryString {
+    param(
+        [string]$QueryString,
+        [string]$Argument
     )
-    if ([string]::IsNullOrEmpty($In)) { return $Add }else { return "$In&$Add" }
+
+    if ($QueryString) {
+        "$QueryString&$Argument"
+    }
+    else {
+        $Argument
+    }
 }
 
 function Invoke-Action1ApiRequest {
@@ -250,6 +285,7 @@ function Invoke-Action1ApiRequest {
         [switch]$RawResponse,
         [switch]$SkipAuthenticationCheck
     )
+
     if ($AddArgs) {
         $Path += "?{0}" -f $AddArgs
     }
@@ -300,11 +336,14 @@ function Invoke-Action1ApiRequest {
     while ($true) {
         Debug-Host "$Method request to $Path. RawResponse flag is $RawResponse"
         try {
-            $webRequestSW = [System.Diagnostics.Stopwatch]::StartNew()
-            $response = Invoke-WebRequest @invokeWebRequestParams
-            $webRequestSW.Stop()
+            if($Script:Action1_DebugEnabled){$webRequestSW = [System.Diagnostics.Stopwatch]::StartNew()}
 
-            Debug-Host ("{2} request to {0} took {1}ms" -f $Path, $($webRequestSW.ElapsedMilliseconds), $Method)
+            $response = Invoke-WebRequest @invokeWebRequestParams
+
+            if($Script:Action1_DebugEnabled){
+                $webRequestSW.Stop()
+                Debug-Host ("{2} request to {0} took {1}ms" -f $Path, $($webRequestSW.ElapsedMilliseconds), $Method)
+            }
 
             if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
                 Debug-Host ("Success response code {0} for {1} to {2}" -f $($response.StatusCode), $Method, $Path)
@@ -369,7 +408,10 @@ function Start-Action1PackageUpload {
     Debug-Host "Uploading file: '$Filename'"
     Debug-Host "Writing in chunks of $BufferSize bytes."
     $FileData = [System.IO.File]::Open($Filename, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
-    if ($FileData.Length -lt $BufferSize) { $BufferSize = $FileData.Length; Debug-Host "File is smaller than BufferSize, adjusting to $($FileData.Length)" }
+    if ($FileData.Length -lt $BufferSize) {
+         $BufferSize = $FileData.Length; 
+         Debug-Host "File is smaller than BufferSize, adjusting to $($FileData.Length)" 
+    }
     $Buffer = New-Object byte[] $BufferSize
     $Place = 0
 
@@ -377,6 +419,7 @@ function Start-Action1PackageUpload {
         'accept'                = '*/*'
         'X-Upload-Content-Type' = 'application/octet-stream'
     }
+
     try {
         $Headers = $HeaderBase.Clone()
         $Headers.Add('X-Upload-Content-Length', $($FileData.Length))
@@ -407,6 +450,7 @@ function Start-Action1PackageUpload {
         catch {
             Debug-Host "Last Status: $($_.Exception.Response.StatusCode)" 
         }
+
         if (($FileData.Length - $Place) -lt $BufferSize) { 
             $buffer = New-Object byte[] ($FileData.Length - $place) 
         }
@@ -414,7 +458,8 @@ function Start-Action1PackageUpload {
 
         if ($Buffer.Length -eq 0) { 
             Debug-Host "Final Status:$($response.StatusCode)" 
-        }else {
+        }
+        else {
             Debug-Host "Bytes Written: $($Buffer.Length)" 
         }
     }
@@ -744,9 +789,12 @@ function Get-Action1 {
     $sbCustomFieldGet = { param([string]$name)($this.custom | Where-Object { $_.name -eq $name }).value }
 
     if ($null -eq $Limit){$Limit=200}
-    if ($Limit -gt 0) { $AddArgs = BuildArgs -In $AddArgs -Add "limit=$Limit"}else{$AddArgs = BuildArgs -In $AddArgs -Add "limit=200"}
-    #if ($From -gt 0) { $AddArgs = BuildArgs -In $AddArgs -Add "from=$From" }
-    #Add more URI arguments here?..
+    if ($Limit -gt 0) { 
+        $AddArgs = Join-QueryString -QueryString $AddArgs -Argument "limit=$Limit"
+    }
+    else {
+        $AddArgs = Join-QueryString -QueryString $AddArgs -Argument "limit=200"
+    }
     if (!$URILookUp["G_$Query"].ToString().Contains("`$Org_ID")) {
         if (!$URILookUp["G_$Query"].ToString().Contains("`$Object_ID")) {
             $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"])
@@ -762,10 +810,10 @@ function Get-Action1 {
     }
     else {
         if ($Id) {
-            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg) -Object_ID $Id)
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_ID $Id)
         }
         else {
-            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg))
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(Initialize-Action1DefaultOrg))
         }
     } 
     if ($Rawlist.Contains($Query)) {
@@ -861,7 +909,7 @@ function New-Action1 {
             $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"])
         }
         else {
-            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"] -Org_ID $(CheckOrg))
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["N_$Item"] -Org_ID $(Initialize-Action1DefaultOrg))
         } 
         return Invoke-Action1ApiRequest -Method POST -Path $Path -Label $Item -Body $Data
     }
@@ -912,7 +960,7 @@ function Update-Action1 {
         'ModifyMembers' {
             switch ($Type) {
                 'EndpointGroup' { 
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupMembers"] -Org_ID $(CheckOrg) -Object_ID $id)
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupMembers"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_ID $id)
                     return Invoke-Action1ApiRequest -Method POST -Path $Path -Body $Data -Label "$Action=>$Type"
                 }
                 default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
@@ -922,21 +970,21 @@ function Update-Action1 {
             if (!$Id) { Write-Error "When perfoming $Action=>$Type, the value for -Id must be specified to know what object to act on."; return $null } 
             switch ($Type) {
                 'Automation' {
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                     return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
                 }
                 'CustomAttribute' {
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                     $Data = New-Object psobject -Property @{"custom:$AttributeName" = $AttributeValue }
                     return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
                 }
                 'Endpoint' { 
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                     $Data.PSObject.Members | ForEach-Object { if (@('name', 'comment') -notcontains $_.Name) { $Data.PSObject.Members.Remove($_.Name) } }
                     return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type" 
                 }
                 'EndpointGroup' { 
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                     return Invoke-Action1ApiRequest -Method PATCH -Path $Path -Body $Data -Label "$Action=>$Type"
                 }
                 default { Write-Error "Invalid request of $Type for query $Action." ; return $null }
@@ -947,19 +995,19 @@ function Update-Action1 {
             switch ($Type) {
                 'EndpointGroup' { 
                     if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_GroupModify"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                         return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
                     }
                 }
                 'Endpoint' { 
                     if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Endpoint"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                         return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
                     }
                 }
                 'Automation' {
                     if ($force -or ((Read-Host "Are you sure you want to $Action $Type [$id]?`n[Y]es to confirm, any other key to cancel.") -eq 'Y')) {
-                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(CheckOrg) -Object_Id $Id)
+                        $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["U_Automation"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_Id $Id)
                         return Invoke-Action1ApiRequest -Method DELETE -Path $Path -Label "$Action=>$Type"
                     }
                 }
@@ -987,15 +1035,15 @@ function Start-Action1Requery {
     else {
         if ($Endpoint_Id) {
             if ($URILookUp["R_$Type"].ToString().Contains("`$Object_ID")) {
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg) -Object_ID $Endpoint_Id)
+                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(Initialize-Action1DefaultOrg) -Object_ID $Endpoint_Id)
             }
             else {
                 Write-Error "Endpoint_Id was specified but this action is not endpoint specific, can continue, defaulting to system wide."
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg))
+                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(Initialize-Action1DefaultOrg))
             } 
         }
         else {
-            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(CheckOrg))
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["R_$Type"] -Org_ID $(Initialize-Action1DefaultOrg))
         }
     } 
 

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -248,7 +248,7 @@ function Invoke-Action1ApiRequest {
         [object]$Body,
         [switch]$RawBody,
         [string]$AddArgs,
-        [switch]$Raw,
+        [switch]$RawResponse,
         [switch]$SkipAuthenticationCheck
     )
     if ($AddArgs) {
@@ -284,7 +284,7 @@ function Invoke-Action1ApiRequest {
         }
     }
 
-    Debug-Host "$Method request to $Path. Raw flag is $Raw"
+    Debug-Host "$Method request to $Path. Raw flag is $RawResponse"
 
     $invokeWebRequestParams = @{
         Uri             = $Path
@@ -305,7 +305,7 @@ function Invoke-Action1ApiRequest {
             $response = Invoke-WebRequest @invokeWebRequestParams
 
             if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
-                if ($Raw) {
+                if ($RawResponse) {
                     return $response.Content
                 }
 
@@ -769,7 +769,7 @@ function Get-Action1 {
         }
     } 
     if ($Rawlist.Contains($Query)) {
-         $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -Raw 
+         $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -RawResponse 
     } 
     else {
          $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs 
@@ -792,7 +792,12 @@ function Get-Action1 {
         }
         While (![string]::IsNullOrEmpty($Page.next_page)) {
             Debug-Host "[$Query] Next page..."
-            if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query }
+            if ($Rawlist.Contains($Query)) {
+                 $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query -RawResponse 
+            } 
+            else {
+                 $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query 
+            }
             switch -Wildcard ($Query) {
                 'PolicyResults' {
                     $page.Items | ForEach-Object {

--- a/PSAction1.psm1
+++ b/PSAction1.psm1
@@ -138,14 +138,14 @@ $PackageDeployTemplate = @"
 #----------------------------------JSON object templates---------------------------------------
 
 function CheckToken() {
-    if (($null -ne $Script:Action1_Token) -and ($Script:Action1_Token.expires_at -ge $(Get-Date))) {
-        Debug-Host "Current token is valid."
+    if (($null -ne $Script:Action1_Token) -and ($null -ne $Script:Action1_Token.access_token) -and ($Script:Action1_Token.expires_at -ge $(Get-Date))) {
+        Write-Debug "Current token is valid."
         return $true
     }
     else {
-        Debug-Host "Token not set or expired, fetching new."
+        Write-Debug "Token not set or expired, fetching new token."
         if (FetchToken -ne $null ) {
-            Debug-Host "Token refresh successful."
+            Write-Debug "Token refresh successful."
             return $true
         }
         else {
@@ -205,7 +205,8 @@ function FetchToken {
                 -Body @{
                     client_id     = $Script:Action1_APIKey
                     client_secret = $Script:Action1_Secret
-                } 
+                } `
+                -SkipAuthenticationCheck
             $Token | Add-Member -MemberType NoteProperty -Name "expires_at" -Value $(Get-Date).AddSeconds(([int]$Token.expires_in - 5)) #Expire token 5 seconds early to avoid race condition timeouts.
             $Script:Action1_Token = $Token
             return $Token
@@ -227,16 +228,10 @@ function BuildArgs {
 }
 
 function Invoke-Action1ApiRequest {
-	[CmdletBinding()]
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [ValidateSet(
-            'GET',
-            'POST',
-            'PUT',
-            'PATCH',
-            'DELETE'
-        )]
+        [ValidateSet('GET', 'POST', 'PUT', 'PATCH', 'DELETE')]
         [string]$Method,
         [Parameter(Mandatory)]
         [string]$Path,
@@ -246,20 +241,25 @@ function Invoke-Action1ApiRequest {
         [object]$Body,
         [switch]$RawBody,
         [string]$AddArgs,
-        [switch]$Raw
+        [switch]$Raw,
+        [switch]$SkipAuthenticationCheck
     )
-
     if ($AddArgs) {
         $Path += "?{0}" -f $AddArgs
     }
 
-    $headers = @{
-        Authorization  = "Bearer $(($Script:Action1_Token).access_token)"
-        'Content-Type' = 'application/json; charset=utf-8'
+    $headers = @{}
+
+    if (-not $SkipAuthenticationCheck) {
+        if (CheckToken) {
+            $headers.Authorization = "Bearer $($Script:Action1_Token.access_token)"
+        }
     }
 
+    $headers['Content-Type'] = 'application/json; charset=utf-8'
+
     if ($Headers) {
-        foreach ($key in $Headers.Keys) {
+        foreach ($key in @($Headers.Keys)) {
             $headers[$key] = $Headers[$key]
         }
     }
@@ -268,31 +268,27 @@ function Invoke-Action1ApiRequest {
 
     if ($PSBoundParameters.ContainsKey('Body') -and $null -ne $Body) {
         if ($RawBody) {
+            Debug-Host "Raw request body supplied. Type: $($requestBody.GetType().FullName)"
             $requestBody = $Body
         }
         else {
+            Debug-Host "JSON Data to be sent:`n$requestBody"
             $requestBody = ConvertTo-Json -InputObject $Body -Depth 10
         }
     }
 
-    Debug-Host "$Method request to $Path. Raw flag is $Raw"
+    Write-Debug "$Method request to $Path. Raw flag is $Raw"
 
     $invokeWebRequestParams = @{
         Uri             = $Path
         Method          = $Method
         UseBasicParsing = $true
         Headers         = $headers
+        ErrorAction     = 'Stop'
     }
 
     if ($null -ne $requestBody) {
         $invokeWebRequestParams.Body = $requestBody
-
-        if ($RawBody) {
-            Debug-Host "Raw request body supplied. Type: $($requestBody.GetType().FullName)"
-        }
-        else {
-            Debug-Host "JSON Data to be sent:`n$requestBody"
-        }
     }
 
     $retry429Count = 0
@@ -302,7 +298,6 @@ function Invoke-Action1ApiRequest {
             $response = Invoke-WebRequest @invokeWebRequestParams
 
             if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
-
                 if ($Raw) {
                     return $response.Content
                 }
@@ -317,12 +312,14 @@ function Invoke-Action1ApiRequest {
             Write-Error "Error processing $($Label): HTTP status code $($response.StatusCode)."
             return $null
         }
-        catch [System.Net.WebException] {
+        catch {
+            $statusCode = $null
 
-            $httpResponse = $_.Exception.Response
+            if ($_.Exception.Response) {
+                $statusCode = [int]$_.Exception.Response.StatusCode
+            }
 
-            if ($httpResponse -and ([int]$httpResponse.StatusCode -eq 429)) {
-
+            if ($statusCode -eq 429) {
                 $retry429Count++
 
                 if ($retry429Count % 2 -eq 1) {
@@ -332,14 +329,12 @@ function Invoke-Action1ApiRequest {
                     $retryTimeout = $Script:Action1_429RetryTimeOutLevel2
                 }
 
-                Debug-Host "HTTP 429 received for $Label. Waiting $retryTimeout ms before retry."
-
+                Write-Debug ("429 received for '{0}'. Retry #{1}. Sleeping {2} ms." -f $Label, $retry429Count, $retryTimeout)
                 Start-Sleep -Milliseconds $retryTimeout
-
                 continue
             }
 
-            Write-Error "Error processing $($Label): $($_)"
+            Write-Error "Error processing $($Label): $($_.Exception.Message)"
             return $null
         }
     }
@@ -547,7 +542,7 @@ function Get-Action1 {
         [string]$Clone
     )
     #Short out processing path if URI literal is specified.
-    if ($Query -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Query is type RawURI.`n"; return $null }else { if (CheckToken) { return Invoke-Action1ApiRequest -Method GET -Path $URI -Label $Query } } }
+    if ($Query -eq 'RawURI') { if (!$URI) { Write-Error "Error -URI value required when Query is type RawURI.`n"; return $null }else { return Invoke-Action1ApiRequest -Method GET -Path $URI -Label $Query } }
     # Retrieve settings objects for post/patch actions.
     if ($Query -eq 'Settings') {
         if (!$For) { 
@@ -729,49 +724,66 @@ function Get-Action1 {
     # Note things that do not get procesed post API call, and should be delivered unaltered.
     $Rawlist = @('ReportExport', 'Logs')
 
-    if (CheckToken) {
-        $AddArgs = ""
-        $sbPolicyResultsDetail = {
-            $Page = Invoke-Action1ApiRequest -Method GET -Path $this.details -Label 'PolicyResultsDetails'
+    $AddArgs = ""
+    $sbPolicyResultsDetail = {
+        $Page = Invoke-Action1ApiRequest -Method GET -Path $this.details -Label 'PolicyResultsDetails'
+        $Page.items | Write-Output
+        While (![string]::IsNullOrEmpty($Page.next_page)) {
+            $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label 'PolicyResultsDetails'
             $Page.items | Write-Output
-            While (![string]::IsNullOrEmpty($Page.next_page)) {
-                $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label 'PolicyResultsDetails'
-                $Page.items | Write-Output
-            }
         }
-        $sbCustomFieldGet = { param([string]$name)($this.custom | Where-Object { $_.name -eq $name }).value }
+    }
+    $sbCustomFieldGet = { param([string]$name)($this.custom | Where-Object { $_.name -eq $name }).value }
 
-        if ($null -eq $Limit){$Limit=200}
-        if ($Limit -gt 0) { $AddArgs = BuildArgs -In $AddArgs -Add "limit=$Limit"}else{$AddArgs = BuildArgs -In $AddArgs -Add "limit=200"}
-        #if ($From -gt 0) { $AddArgs = BuildArgs -In $AddArgs -Add "from=$From" }
-        #Add more URI arguments here?..
-        if (!$URILookUp["G_$Query"].ToString().Contains("`$Org_ID")) {
-            if (!$URILookUp["G_$Query"].ToString().Contains("`$Object_ID")) {
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"])
-            }
-            else {
-                if ($Id) {
-                    $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Object_ID $Id)
-                }
-                else {
-                    Write-Error 'This options requires that you specify an Object_ID.'
-                }
-            }
+    if ($null -eq $Limit){$Limit=200}
+    if ($Limit -gt 0) { $AddArgs = BuildArgs -In $AddArgs -Add "limit=$Limit"}else{$AddArgs = BuildArgs -In $AddArgs -Add "limit=200"}
+    #if ($From -gt 0) { $AddArgs = BuildArgs -In $AddArgs -Add "from=$From" }
+    #Add more URI arguments here?..
+    if (!$URILookUp["G_$Query"].ToString().Contains("`$Org_ID")) {
+        if (!$URILookUp["G_$Query"].ToString().Contains("`$Object_ID")) {
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"])
         }
         else {
             if ($Id) {
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg) -Object_ID $Id)
+                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Object_ID $Id)
             }
             else {
-                $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg))
+                Write-Error 'This options requires that you specify an Object_ID.'
             }
-        } 
-        if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs }
-        if ($Page.items) {
+        }
+    }
+    else {
+        if ($Id) {
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg) -Object_ID $Id)
+        }
+        else {
+            $Path = "$Script:Action1_BaseURI{0}" -f (& $URILookUp["G_$Query"] -Org_ID $(CheckOrg))
+        }
+    } 
+    if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Path -Label $Query -AddArgs $AddArgs }
+    if ($Page.items) {
+        switch -Wildcard ($Query) {
+            'PolicyResults' {
+                $page.Items | ForEach-Object {
+                    $_ | Add-Member -MemberType ScriptMethod -Name "GetDetails" -Value $sbPolicyResultsDetail
+                    Write-Output $_
+                }
+            }
+            'Endpoint*' {
+                $page.Items | ForEach-Object {
+                    $_ | Add-Member -MemberType ScriptMethod -Name "GetCustomAttribute" -Value $sbCustomFieldGet
+                    Write-Output $_
+                }  
+            }
+            default { $Page.Items | Write-Output }
+        }
+        While (![string]::IsNullOrEmpty($Page.next_page)) {
+            Debug-Host "[$Query] Next page..."
+            if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query }
             switch -Wildcard ($Query) {
                 'PolicyResults' {
                     $page.Items | ForEach-Object {
-                        $_ | Add-Member -MemberType ScriptMethod -Name "GetDetails" -Value $sbPolicyResultsDetail
+                        $_ | Add-Member -MemberType ScriptMethod -Name "GetDetails" -Value sbPolicyResultsDetail
                         Write-Output $_
                     }
                 }
@@ -783,37 +795,19 @@ function Get-Action1 {
                 }
                 default { $Page.Items | Write-Output }
             }
-            While (![string]::IsNullOrEmpty($Page.next_page)) {
-                Debug-Host "[$Query] Next page..."
-                if ($Rawlist.Contains($Query)) { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query -Raw } else { $Page = Invoke-Action1ApiRequest -Method GET -Path $Page.next_page -Label $Query }
-                switch -Wildcard ($Query) {
-                    'PolicyResults' {
-                        $page.Items | ForEach-Object {
-                            $_ | Add-Member -MemberType ScriptMethod -Name "GetDetails" -Value sbPolicyResultsDetail
-                            Write-Output $_
-                        }
-                    }
-                    'Endpoint*' {
-                        $page.Items | ForEach-Object {
-                            $_ | Add-Member -MemberType ScriptMethod -Name "GetCustomAttribute" -Value $sbCustomFieldGet
-                            Write-Output $_
-                        }  
-                    }
-                    default { $Page.Items | Write-Output }
-                }
-            }
         }
-        else {
-            switch -Wildcard ($Query) {
-                'Endpoint*' {
-                    $Page | Add-Member -MemberType ScriptMethod -Name "GetCustomAttribute" -Value $sbCustomFieldGet
-                    Write-Output $Page
-                    
-                }
-                default { Write-Output $Page }
-            }
-        }                
     }
+    else {
+        switch -Wildcard ($Query) {
+            'Endpoint*' {
+                $Page | Add-Member -MemberType ScriptMethod -Name "GetCustomAttribute" -Value $sbCustomFieldGet
+                Write-Output $Page
+                
+            }
+            default { Write-Output $Page }
+        }
+    }                
+    
 }
 
 function New-Action1 {

--- a/docs/help/Set-Action1Locale.md
+++ b/docs/help/Set-Action1Locale.md
@@ -72,7 +72,7 @@ Parameter Sets: (All)
 
 Aliases:
 
-Accepted values: NorthAmerica, Europe
+Accepted values: NorthAmerica, Europe, Australia
 
 Required: True
 


### PR DESCRIPTION
1. Create universal solid Invoke-Action1ApiRequest{} function to handle 429 HTTP code
2. Replace DoGet{} with Invoke-Action1ApiRequest{}
3. Replace PushData{} with Invoke-Action1ApiRequest{}
4. Replace standard Invoke-WebRequest{} calling with Invoke-Action1ApiRequest{} everywhere
5. The only one Invoke-WebRequest{} call left in the module inside Invoke-Action1ApiRequest{}