### PR TITLE
Feature/27676 pipeline endpoint group

### DIFF
--- a/Public/EndpointGroup/Add-Action1EndpointGroupMembers.ps1
+++ b/Public/EndpointGroup/Add-Action1EndpointGroupMembers.ps1
@@ -8,22 +8,29 @@
 function Add-Action1EndpointGroupMembers {
     [CmdletBinding(
         SupportsShouldProcess = $true,
-        DefaultParameterSetName = 'ByGroupId'
+        DefaultParameterSetName = 'ByGroupIdEndpointIds'
     )]
     param(
         [Parameter(
             Mandatory = $true,
-            ParameterSetName = 'ByGroupId',
+            ParameterSetName = 'ByGroupIdEndpointIds',
+            Position = 0
+        )]
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = 'ByGroupIdEndpointObjects',
             Position = 0
         )]
         [ValidateNotNullOrEmpty()]
         [string]$GroupId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupName')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupNameEndpointIds')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupNameEndpointObjects')]
         [ValidateNotNullOrEmpty()]
         [string]$GroupName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupIdEndpointIds')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupNameEndpointIds')]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({
             if (-not (Test-Guid $_)) {
@@ -34,69 +41,111 @@ function Add-Action1EndpointGroupMembers {
         })]
         [string[]]$EndpointIds,
 
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = 'ByGroupIdEndpointObjects',
+            ValueFromPipeline = $true
+        )]
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = 'ByGroupNameEndpointObjects',
+            ValueFromPipeline = $true
+        )]
+        [AllowNull()]
+        [object[]]$EndpointObjects,
+
         [switch]$Force
     )
 
-    if (Initialize-Action1DefaultOrg) {
-        $orgId = Get-Action1DefaultOrgId
-    }
+    begin {
+        $endpointIdValues = New-Object System.Collections.ArrayList
 
-    if ($PSCmdlet.ParameterSetName -eq 'ByGroupName') {
-        $endpointGroup = Resolve-Action1EndpointGroupByName -GroupName $GroupName
-    }
-    else {
-        $endpointGroup = Resolve-Action1EndpointGroupById -GroupId $GroupId
-    }
-
-    $resolvedGroupId = $endpointGroup.id
-    $endpointIdValues = @(
-        foreach ($endpointId in $EndpointIds) {
-            $endpointId.Trim()
+        if ($Force) {
+            $ConfirmPreference = 'None'
         }
-    )
+    }
 
-    $uriPathBuilder = Get-UriMapValue -Key 'N_EndpointGroupMembers'
+    process {
+        if ($PSCmdlet.ParameterSetName -like '*EndpointObjects') {
+            foreach ($endpointObject in $EndpointObjects) {
+                $endpointIdentity = Get-Action1EndpointIdentityFromObject `
+                    -EndpointObject $endpointObject
 
-    $uri = & $uriPathBuilder $orgId $resolvedGroupId
-    $path = "$Script:Action1_BaseURI{0}" -f $uri
-    $endpointCount = $endpointIdValues.Count
-    $groupLabel = "endpoint group '$resolvedGroupId'"
-
-    $body = @(
-        foreach ($endpointIdValue in $endpointIdValues) {
-            [ordered]@{
-                method = 'POST'
-                data   = [ordered]@{
-                    endpoint_id = $endpointIdValue
-                    type        = 'Endpoint'
+                if (-not $endpointIdentity.IsValid) {
+                    Write-Action1Debug $endpointIdentity.ErrorMessage
+                    Write-Error $endpointIdentity.ErrorMessage
+                    continue
                 }
+
+                [void]$endpointIdValues.Add($endpointIdentity.EndpointId)
             }
         }
-    )
-
-    if ($Force) {
-        $ConfirmPreference = 'None'
+        else {
+            foreach ($endpointId in $EndpointIds) {
+                [void]$endpointIdValues.Add($endpointId.Trim())
+            }
+        }
     }
 
-    if (-not $PSCmdlet.ShouldProcess($groupLabel, "Add $endpointCount endpoints")) {
-        Write-Action1Debug "Skipped adding $endpointCount endpoints to $groupLabel."
-        return
+    end {
+        $endpointCount = $endpointIdValues.Count
+
+        if ($endpointCount -eq 0) {
+            Write-Error 'No valid endpoint IDs were supplied.'
+            return
+        }
+
+        if (Initialize-Action1DefaultOrg) {
+            $orgId = Get-Action1DefaultOrgId
+        }
+
+        if ($PSCmdlet.ParameterSetName -like 'ByGroupName*') {
+            $endpointGroup = Resolve-Action1EndpointGroupByName -GroupName $GroupName
+        }
+        else {
+            $endpointGroup = Resolve-Action1EndpointGroupById -GroupId $GroupId
+        }
+
+        $resolvedGroupId = $endpointGroup.id
+
+        $uriPathBuilder = Get-UriMapValue -Key 'N_EndpointGroupMembers'
+
+        $uri = & $uriPathBuilder $orgId $resolvedGroupId
+        $path = "$Script:Action1_BaseURI{0}" -f $uri
+        $groupLabel = "endpoint group '$resolvedGroupId'"
+
+        $body = @(
+            foreach ($endpointIdValue in $endpointIdValues) {
+                [ordered]@{
+                    method = 'POST'
+                    data   = [ordered]@{
+                        endpoint_id = $endpointIdValue
+                        type        = 'Endpoint'
+                    }
+                }
+            }
+        )
+
+        if (-not $PSCmdlet.ShouldProcess($groupLabel, "Add $endpointCount endpoints")) {
+            Write-Action1Debug "Skipped adding $endpointCount endpoints to $groupLabel."
+            return
+        }
+
+        Write-Action1Debug "Adding $endpointCount endpoints to $groupLabel."
+
+        $response = Invoke-Action1ApiRequest `
+            -Method POST `
+            -Path $path `
+            -Label "Add endpoints to $groupLabel" `
+            -Body $body
+
+        if ($null -eq $response) {
+            Write-Error "Failed to add $endpointCount endpoints to $groupLabel."
+            return
+        }
+
+        Write-Action1Debug "Added $endpointCount endpoints to $groupLabel."
+
+        $response
     }
-
-    Write-Action1Debug "Adding $endpointCount endpoints to $groupLabel."
-
-    $response = Invoke-Action1ApiRequest `
-        -Method POST `
-        -Path $path `
-        -Label "Add endpoints to $groupLabel" `
-        -Body $body
-
-    if ($null -eq $response) {
-        Write-Error "Failed to add $endpointCount endpoints to $groupLabel."
-        return
-    }
-
-    Write-Action1Debug "Added $endpointCount endpoints to $groupLabel."
-
-    $response
 }

--- a/Public/EndpointGroup/Remove-Action1EndpointGroupMembers.ps1
+++ b/Public/EndpointGroup/Remove-Action1EndpointGroupMembers.ps1
@@ -8,22 +8,29 @@
 function Remove-Action1EndpointGroupMembers {
     [CmdletBinding(
         SupportsShouldProcess = $true,
-        DefaultParameterSetName = 'ByGroupId'
+        DefaultParameterSetName = 'ByGroupIdEndpointIds'
     )]
     param(
         [Parameter(
             Mandatory = $true,
-            ParameterSetName = 'ByGroupId',
+            ParameterSetName = 'ByGroupIdEndpointIds',
+            Position = 0
+        )]
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = 'ByGroupIdEndpointObjects',
             Position = 0
         )]
         [ValidateNotNullOrEmpty()]
         [string]$GroupId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupName')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupNameEndpointIds')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupNameEndpointObjects')]
         [ValidateNotNullOrEmpty()]
         [string]$GroupName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupIdEndpointIds')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByGroupNameEndpointIds')]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({
             if (-not (Test-Guid $_)) {
@@ -34,66 +41,112 @@ function Remove-Action1EndpointGroupMembers {
         })]
         [string[]]$EndpointIds,
 
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = 'ByGroupIdEndpointObjects',
+            ValueFromPipeline = $true
+        )]
+        [Parameter(
+            Mandatory = $true,
+            ParameterSetName = 'ByGroupNameEndpointObjects',
+            ValueFromPipeline = $true
+        )]
+        [AllowNull()]
+        [object[]]$EndpointObjects,
+
         [switch]$Force
     )
 
-    if (Initialize-Action1DefaultOrg) {
-        $orgId = Get-Action1DefaultOrgId
-    }
+    begin {
+        $endpointIdValues = New-Object System.Collections.ArrayList
 
-    if ($PSCmdlet.ParameterSetName -eq 'ByGroupName') {
-        $endpointGroup = Resolve-Action1EndpointGroupByName -GroupName $GroupName
-    }
-    else {
-        $endpointGroup = Resolve-Action1EndpointGroupById -GroupId $GroupId
-    }
-
-    $resolvedGroupId = $endpointGroup.id
-    $endpointIdValues = @(
-        foreach ($endpointId in $EndpointIds) {
-            $endpointId.Trim()
+        if ($Force) {
+            $ConfirmPreference = 'None'
         }
-    )
+    }
 
-    $uriPathBuilder = Get-UriMapValue -Key 'D_EndpointGroupMembers'
+    process {
+        if ($PSCmdlet.ParameterSetName -like '*EndpointObjects') {
+            foreach ($endpointObject in $EndpointObjects) {
+                $endpointIdentity = Get-Action1EndpointIdentityFromObject `
+                    -EndpointObject $endpointObject
 
-    $uri = & $uriPathBuilder $orgId $resolvedGroupId
-    $path = "$Script:Action1_BaseURI{0}" -f $uri
-    $endpointCount = $endpointIdValues.Count
-    $groupLabel = "endpoint group '$resolvedGroupId'"
+                if (-not $endpointIdentity.IsValid) {
+                    Write-Action1Debug $endpointIdentity.ErrorMessage
+                    Write-Error $endpointIdentity.ErrorMessage
+                    continue
+                }
 
-    $body = @(
-        foreach ($endpointIdValue in $endpointIdValues) {
-            [ordered]@{
-                method      = 'DELETE'
-                endpoint_id = $endpointIdValue
+                [void]$endpointIdValues.Add($endpointIdentity.EndpointId)
             }
         }
-    )
-
-    if ($Force) {
-        $ConfirmPreference = 'None'
+        else {
+            foreach ($endpointId in $EndpointIds) {
+                [void]$endpointIdValues.Add($endpointId.Trim())
+            }
+        }
     }
 
-    if (-not $PSCmdlet.ShouldProcess($groupLabel, "Remove $endpointCount endpoints")) {
-        Write-Action1Debug "Skipped removing $endpointCount endpoints from $groupLabel."
-        return
+    end {
+        $endpointCount = $endpointIdValues.Count
+
+        if ($endpointCount -eq 0) {
+            Write-Error 'No valid endpoint IDs were supplied.'
+            return
+        }
+
+        if (Initialize-Action1DefaultOrg) {
+            $orgId = Get-Action1DefaultOrgId
+        }
+
+        if ($PSCmdlet.ParameterSetName -like 'ByGroupName*') {
+            $endpointGroup = Resolve-Action1EndpointGroupByName -GroupName $GroupName
+        }
+        else {
+            $endpointGroup = Resolve-Action1EndpointGroupById -GroupId $GroupId
+        }
+
+        $resolvedGroupId = $endpointGroup.id
+
+        $uriPathBuilder = Get-UriMapValue -Key 'D_EndpointGroupMembers'
+
+        $uri = & $uriPathBuilder $orgId $resolvedGroupId
+        $path = "$Script:Action1_BaseURI{0}" -f $uri
+        $groupLabel = "endpoint group '$resolvedGroupId'"
+
+        $body = @(
+            foreach ($endpointIdValue in $endpointIdValues) {
+                [ordered]@{
+                    method      = 'DELETE'
+                    endpoint_id = $endpointIdValue
+                }
+            }
+        )
+
+        $operation = "Remove $endpointCount endpoints"
+
+        if (-not $PSCmdlet.ShouldProcess($groupLabel, $operation)) {
+            Write-Action1Debug (
+                "Skipped removing $endpointCount endpoints from $groupLabel."
+            )
+            return
+        }
+
+        Write-Action1Debug "Removing $endpointCount endpoints from $groupLabel."
+
+        $response = Invoke-Action1ApiRequest `
+            -Method POST `
+            -Path $path `
+            -Label "Remove endpoints from $groupLabel" `
+            -Body $body
+
+        if ($null -eq $response) {
+            Write-Error "Failed to remove $endpointCount endpoints from $groupLabel."
+            return
+        }
+
+        Write-Action1Debug "Removed $endpointCount endpoints from $groupLabel."
+
+        $response
     }
-
-    Write-Action1Debug "Removing $endpointCount endpoints from $groupLabel."
-
-    $response = Invoke-Action1ApiRequest `
-        -Method POST `
-        -Path $path `
-        -Label "Remove endpoints from $groupLabel" `
-        -Body $body
-
-    if ($null -eq $response) {
-        Write-Error "Failed to remove $endpointCount endpoints from $groupLabel."
-        return
-    }
-
-    Write-Action1Debug "Removed $endpointCount endpoints from $groupLabel."
-
-    $response
 }

--- a/docs/help/endpoint/Get-Action1Endpoints.md
+++ b/docs/help/endpoint/Get-Action1Endpoints.md
@@ -84,6 +84,36 @@ Get-Action1Endpoints -Status Connected |
 
 Gets connected endpoints and selects key fields.
 
+### Example 7: Add filtered endpoints to an endpoint group
+
+```powershell
+Get-Action1Endpoints `
+    -Status Connected `
+    -RebootRequired No `
+    -OS 'Windows 11' |
+    Add-Action1EndpointGroupMembers -GroupName 'Windows 11 Workstations'
+```
+
+Gets connected Windows 11 endpoints that do not require reboot, then pipes the
+endpoint objects to **Add-Action1EndpointGroupMembers**. The receiving command
+collects the endpoint IDs and sends one bulk API request to add them to the
+endpoint group.
+
+### Example 8: Preview adding filtered endpoints to an endpoint group
+
+```powershell
+Get-Action1Endpoints `
+    -Status Connected `
+    -RebootRequired Yes `
+    -OS 'Windows Server' |
+    Add-Action1EndpointGroupMembers `
+        -GroupName 'Servers Pending Reboot' `
+        -WhatIf
+```
+
+Gets connected Windows Server endpoints that require reboot, then previews the
+endpoint group membership update without sending the add request.
+
 ## PARAMETERS
 
 ### -OS
@@ -178,7 +208,9 @@ You cannot pipe input to this command.
 
 ### System.Object
 
-Returns managed endpoint objects from Action1.
+Returns managed endpoint objects from Action1. The objects include an `id`
+property and can be piped to commands that accept endpoint objects, such as
+**Add-Action1EndpointGroupMembers**.
 
 ## NOTES
 
@@ -189,3 +221,5 @@ The command retrieves paged results from the Action1 API and returns endpoint ob
 ## RELATED LINKS
 
 [Set-Action1DefaultOrg](../configuration/Set-Action1DefaultOrg.md)
+[Add-Action1EndpointGroupMembers](../endpointgroup/Add-Action1EndpointGroupMembers.md)
+[Get-Action1EndpointGroupMembers](../endpointgroup/Get-Action1EndpointGroupMembers.md)

--- a/docs/help/endpointgroup/Add-Action1EndpointGroupMembers.md
+++ b/docs/help/endpointgroup/Add-Action1EndpointGroupMembers.md
@@ -233,7 +233,7 @@ error.
 
 ```yaml
 Type: String
-Parameter Sets: ByGroupNameEndpointIds, ByGroupNameEndpointObjects
+Parameter Sets: ByGroupNameEndpointObjects, ByGroupNameEndpointIds
 Aliases:
 
 Required: True

--- a/docs/help/endpointgroup/Add-Action1EndpointGroupMembers.md
+++ b/docs/help/endpointgroup/Add-Action1EndpointGroupMembers.md
@@ -13,13 +13,25 @@ Adds multiple endpoints to an endpoint group in the current Action1 organization
 
 ## SYNTAX
 
-### ByGroupId (Default)
+### ByGroupIdEndpointIds (Default)
 ```
 Add-Action1EndpointGroupMembers [-GroupId] <String> -EndpointIds <String[]> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-### ByGroupName
+### ByGroupIdEndpointObjects
+```
+Add-Action1EndpointGroupMembers [-GroupId] <String> -EndpointObjects <Object[]> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### ByGroupNameEndpointObjects
+```
+Add-Action1EndpointGroupMembers -GroupName <String> -EndpointObjects <Object[]> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### ByGroupNameEndpointIds
 ```
 Add-Action1EndpointGroupMembers -GroupName <String> -EndpointIds <String[]> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -39,6 +51,12 @@ Each **-EndpointIds** value must use the standard GUID format. The command sends
 an Action1 group-member operation for each endpoint ID with `method` set to
 `POST`, `type` set to `Endpoint`, and `endpoint_id` set to the supplied endpoint
 ID.
+
+You can also pipe endpoint objects to the command. Piped endpoint objects must
+include an `id` property that contains the endpoint GUID. The command collects
+valid endpoint IDs from all pipeline input before sending a single API request.
+Invalid piped objects are reported and skipped. If no valid endpoint IDs are
+supplied, the command does not call the API.
 
 Use **-WhatIf** to preview the operation. Use **-Force** to bypass confirmation
 prompts.
@@ -77,7 +95,35 @@ Add-Action1EndpointGroupMembers `
 Resolves the endpoint group named Workstations and adds the endpoints to that
 group.
 
-### Example 3: Preview the request
+### Example 3: Add piped group members to another group
+
+```powershell
+Get-Action1EndpointGroupMembers `
+    -GroupName 'Pilot Workstations' `
+    -Status Connected `
+    -RebootRequired No `
+    -OS 'Windows 11' |
+    Add-Action1EndpointGroupMembers -GroupName 'Production Workstations'
+```
+
+Gets connected Windows 11 endpoints that do not require reboot from the Pilot
+Workstations endpoint group, collects their endpoint IDs, and adds them to the
+Production Workstations endpoint group with one API request.
+
+### Example 4: Add filtered endpoints from the organization endpoint list
+
+```powershell
+Get-Action1Endpoints `
+    -Status Connected `
+    -RebootRequired Yes `
+    -OS 'Windows Server' |
+    Add-Action1EndpointGroupMembers -GroupName 'Servers Pending Reboot'
+```
+
+Gets connected Windows Server endpoints that require reboot from the current
+organization and adds them to the Servers Pending Reboot endpoint group.
+
+### Example 5: Preview the request
 
 ```powershell
 Add-Action1EndpointGroupMembers `
@@ -113,13 +159,33 @@ Each value must use the standard GUID format.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
+Parameter Sets: ByGroupIdEndpointIds, ByGroupNameEndpointIds
 Aliases:
 
 Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndpointObjects
+
+Specifies endpoint objects to add to the endpoint group. The command accepts
+these objects from the pipeline.
+
+Each object must include an `id` property that contains a standard endpoint
+GUID. Invalid objects are reported and skipped.
+
+```yaml
+Type: Object[]
+Parameter Sets: ByGroupIdEndpointObjects, ByGroupNameEndpointObjects
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -147,7 +213,7 @@ Endpoint group IDs are opaque strings, not GUIDs.
 
 ```yaml
 Type: String
-Parameter Sets: ByGroupId
+Parameter Sets: ByGroupIdEndpointIds, ByGroupIdEndpointObjects
 Aliases:
 
 Required: True
@@ -167,7 +233,7 @@ error.
 
 ```yaml
 Type: String
-Parameter Sets: ByGroupName
+Parameter Sets: ByGroupNameEndpointIds, ByGroupNameEndpointObjects
 Aliases:
 
 Required: True
@@ -197,9 +263,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.Object
 
-You cannot pipe input to this command.
+You can pipe endpoint objects with an `id` property to this command.
 
 ## OUTPUTS
 
@@ -220,4 +286,5 @@ The command sends a POST request to the endpoint group contents API path:
 [Get-Action1EndpointGroup](Get-Action1EndpointGroup.md)
 [Get-Action1EndpointGroups](Get-Action1EndpointGroups.md)
 [Get-Action1EndpointGroupMembers](Get-Action1EndpointGroupMembers.md)
+[Get-Action1Endpoints](../endpoint/Get-Action1Endpoints.md)
 [Set-Action1DefaultOrg](../configuration/Set-Action1DefaultOrg.md)

--- a/docs/help/endpointgroup/Get-Action1EndpointGroupMembers.md
+++ b/docs/help/endpointgroup/Get-Action1EndpointGroupMembers.md
@@ -96,6 +96,38 @@ Get-Action1EndpointGroupMembers -GroupName 'Workstations' |
 
 Gets endpoints from the endpoint group and selects key fields.
 
+### Example 6: Add filtered group members to another endpoint group
+
+```powershell
+Get-Action1EndpointGroupMembers `
+    -GroupName 'Pilot Workstations' `
+    -Status Connected `
+    -RebootRequired No `
+    -OS 'Windows 11' |
+    Add-Action1EndpointGroupMembers -GroupName 'Production Workstations'
+```
+
+Gets connected Windows 11 endpoints that do not require reboot from the Pilot
+Workstations endpoint group, then pipes them to
+**Add-Action1EndpointGroupMembers**. The add command collects the endpoint IDs
+and sends one bulk API request.
+
+### Example 7: Preview removing filtered group members
+
+```powershell
+Get-Action1EndpointGroupMembers `
+    -GroupName 'Retired Workstations' `
+    -Status Disconnected `
+    -RebootRequired All `
+    -OS 'Windows 10' |
+    Remove-Action1EndpointGroupMembers `
+        -GroupName 'Retired Workstations' `
+        -WhatIf
+```
+
+Gets disconnected Windows 10 endpoints from the Retired Workstations endpoint
+group, then previews removing those endpoints from the same group.
+
 ## PARAMETERS
 
 ### -GroupId
@@ -226,7 +258,9 @@ You cannot pipe input to this command.
 
 ### System.Object
 
-Returns endpoint objects from Action1.
+Returns endpoint objects from Action1. The objects include an `id` property and
+can be piped to **Add-Action1EndpointGroupMembers** or
+**Remove-Action1EndpointGroupMembers**.
 
 ## NOTES
 
@@ -241,5 +275,7 @@ endpoint to indicate how the endpoint came to this group.
 
 [Get-Action1EndpointGroup](Get-Action1EndpointGroup.md)
 [Get-Action1EndpointGroups](Get-Action1EndpointGroups.md)
-[Get-Action1Endpoints](Get-Action1Endpoints.md)
+[Get-Action1Endpoints](../endpoint/Get-Action1Endpoints.md)
+[Add-Action1EndpointGroupMembers](Add-Action1EndpointGroupMembers.md)
+[Remove-Action1EndpointGroupMembers](Remove-Action1EndpointGroupMembers.md)
 [Set-Action1DefaultOrg](../configuration/Set-Action1DefaultOrg.md)

--- a/docs/help/endpointgroup/Remove-Action1EndpointGroupMembers.md
+++ b/docs/help/endpointgroup/Remove-Action1EndpointGroupMembers.md
@@ -21,14 +21,14 @@ Remove-Action1EndpointGroupMembers [-GroupId] <String> -EndpointIds <String[]> [
 
 ### ByGroupIdEndpointObjects
 ```
-Remove-Action1EndpointGroupMembers [-GroupId] <String> -EndpointObjects <Object[]> [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Remove-Action1EndpointGroupMembers [-GroupId] <String> -EndpointObjects <Object[]> [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### ByGroupNameEndpointObjects
 ```
-Remove-Action1EndpointGroupMembers -GroupName <String> -EndpointObjects <Object[]> [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Remove-Action1EndpointGroupMembers -GroupName <String> -EndpointObjects <Object[]> [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### ByGroupNameEndpointIds
@@ -236,7 +236,7 @@ error.
 
 ```yaml
 Type: String
-Parameter Sets: ByGroupNameEndpointIds, ByGroupNameEndpointObjects
+Parameter Sets: ByGroupNameEndpointObjects, ByGroupNameEndpointIds
 Aliases:
 
 Required: True

--- a/docs/help/endpointgroup/Remove-Action1EndpointGroupMembers.md
+++ b/docs/help/endpointgroup/Remove-Action1EndpointGroupMembers.md
@@ -13,13 +13,25 @@ Removes multiple endpoints from an endpoint group in the current Action1 organiz
 
 ## SYNTAX
 
-### ByGroupId (Default)
+### ByGroupIdEndpointIds (Default)
 ```
 Remove-Action1EndpointGroupMembers [-GroupId] <String> -EndpointIds <String[]> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-### ByGroupName
+### ByGroupIdEndpointObjects
+```
+Remove-Action1EndpointGroupMembers [-GroupId] <String> -EndpointObjects <Object[]> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### ByGroupNameEndpointObjects
+```
+Remove-Action1EndpointGroupMembers -GroupName <String> -EndpointObjects <Object[]> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### ByGroupNameEndpointIds
 ```
 Remove-Action1EndpointGroupMembers -GroupName <String> -EndpointIds <String[]> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -38,6 +50,12 @@ API path with the resolved ID.
 Each **-EndpointIds** value must use the standard GUID format. The command sends
 an Action1 group-member operation for each endpoint ID with `method` set to
 `DELETE` and `endpoint_id` set to the supplied endpoint ID.
+
+You can also pipe endpoint objects to the command. Piped endpoint objects must
+include an `id` property that contains the endpoint GUID. The command collects
+valid endpoint IDs from all pipeline input before sending a single API request.
+Invalid piped objects are reported and skipped. If no valid endpoint IDs are
+supplied, the command does not call the API.
 
 Use **-WhatIf** to preview the operation. Use **-Force** to bypass confirmation
 prompts.
@@ -77,7 +95,38 @@ Remove-Action1EndpointGroupMembers `
 Resolves the endpoint group named Workstations and removes the endpoints from
 that group.
 
-### Example 3: Preview the request
+### Example 3: Remove piped members from a group
+
+```powershell
+Get-Action1EndpointGroupMembers `
+    -GroupName 'Retired Workstations' `
+    -Status Disconnected `
+    -RebootRequired All `
+    -OS 'Windows 10' |
+    Remove-Action1EndpointGroupMembers -GroupName 'Retired Workstations'
+```
+
+Gets disconnected Windows 10 endpoints from the Retired Workstations endpoint
+group, collects their endpoint IDs, and removes those endpoints from the same
+endpoint group with one API request.
+
+### Example 4: Preview removing filtered group members
+
+```powershell
+Get-Action1EndpointGroupMembers `
+    -GroupName 'Workstations' `
+    -Status Connected `
+    -RebootRequired Yes `
+    -OS 'Windows 11' |
+    Remove-Action1EndpointGroupMembers `
+        -GroupName 'Workstations' `
+        -WhatIf
+```
+
+Gets connected Windows 11 endpoints that require reboot from the Workstations
+endpoint group, then previews removing those endpoints from the group.
+
+### Example 5: Preview the request
 
 ```powershell
 Remove-Action1EndpointGroupMembers `
@@ -113,13 +162,33 @@ Each value must use the standard GUID format.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
+Parameter Sets: ByGroupIdEndpointIds, ByGroupNameEndpointIds
 Aliases:
 
 Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndpointObjects
+
+Specifies endpoint objects to remove from the endpoint group. The command
+accepts these objects from the pipeline.
+
+Each object must include an `id` property that contains a standard endpoint
+GUID. Invalid objects are reported and skipped.
+
+```yaml
+Type: Object[]
+Parameter Sets: ByGroupIdEndpointObjects, ByGroupNameEndpointObjects
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -147,7 +216,7 @@ Endpoint group IDs are opaque strings, not GUIDs.
 
 ```yaml
 Type: String
-Parameter Sets: ByGroupId
+Parameter Sets: ByGroupIdEndpointIds, ByGroupIdEndpointObjects
 Aliases:
 
 Required: True
@@ -167,7 +236,7 @@ error.
 
 ```yaml
 Type: String
-Parameter Sets: ByGroupName
+Parameter Sets: ByGroupNameEndpointIds, ByGroupNameEndpointObjects
 Aliases:
 
 Required: True
@@ -197,9 +266,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.Object
 
-You cannot pipe input to this command.
+You can pipe endpoint objects with an `id` property to this command.
 
 ## OUTPUTS
 
@@ -221,4 +290,5 @@ The command sends a POST request to the endpoint group contents API path:
 [Get-Action1EndpointGroup](Get-Action1EndpointGroup.md)
 [Get-Action1EndpointGroups](Get-Action1EndpointGroups.md)
 [Get-Action1EndpointGroupMembers](Get-Action1EndpointGroupMembers.md)
+[Get-Action1Endpoints](../endpoint/Get-Action1Endpoints.md)
 [Set-Action1DefaultOrg](../configuration/Set-Action1DefaultOrg.md)

--- a/en-US/PSAction1-help.xml
+++ b/en-US/PSAction1-help.xml
@@ -1446,7 +1446,7 @@ Europe</dev:code>
           <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
-          <maml:para>Returns managed endpoint objects from Action1.</maml:para>
+          <maml:para>Returns managed endpoint objects from Action1. The objects include an `id` property and can be piped to commands that accept endpoint objects, such as Add-Action1EndpointGroupMembers .</maml:para>
         </maml:description>
       </command:returnValue>
     </command:returnValues>
@@ -1501,10 +1501,42 @@ Europe</dev:code>
           <maml:para>Gets connected endpoints and selects key fields.</maml:para>
         </dev:remarks>
       </command:example>
+      <command:example>
+        <maml:title>---- Example 7: Add filtered endpoints to an endpoint group ----</maml:title>
+        <dev:code>Get-Action1Endpoints `
+    -Status Connected `
+    -RebootRequired No `
+    -OS 'Windows 11' |
+    Add-Action1EndpointGroupMembers -GroupName 'Windows 11 Workstations'</dev:code>
+        <dev:remarks>
+          <maml:para>Gets connected Windows 11 endpoints that do not require reboot, then pipes the endpoint objects to Add-Action1EndpointGroupMembers . The receiving command collects the endpoint IDs and sends one bulk API request to add them to the endpoint group.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 8: Preview adding filtered endpoints to an endpoint group</maml:title>
+        <dev:code>Get-Action1Endpoints `
+    -Status Connected `
+    -RebootRequired Yes `
+    -OS 'Windows Server' |
+    Add-Action1EndpointGroupMembers `
+        -GroupName 'Servers Pending Reboot' `
+        -WhatIf</dev:code>
+        <dev:remarks>
+          <maml:para>Gets connected Windows Server endpoints that require reboot, then previews the endpoint group membership update without sending the add request.</maml:para>
+        </dev:remarks>
+      </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Set-Action1DefaultOrg</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Add-Action1EndpointGroupMembers</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Get-Action1EndpointGroupMembers</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
@@ -2774,6 +2806,7 @@ Update-Action1Endpoint -EndpointObject $endpoint -Comment 'Assigned to accountin
       <maml:para>Adds managed endpoints to a specific endpoint group by calling the Action1 endpoint group contents API once with one operation object per endpoint.</maml:para>
       <maml:para>The command accepts an endpoint group ID or an endpoint group name. When -GroupName is used, the command resolves the name by searching endpoint groups in the current organization and then calls the endpoint group contents API path with the resolved ID.</maml:para>
       <maml:para>Each -EndpointIds value must use the standard GUID format. The command sends an Action1 group-member operation for each endpoint ID with `method` set to `POST`, `type` set to `Endpoint`, and `endpoint_id` set to the supplied endpoint ID.</maml:para>
+      <maml:para>You can also pipe endpoint objects to the command. Piped endpoint objects must include an `id` property that contains the endpoint GUID. The command collects valid endpoint IDs from all pipeline input before sending a single API request. Invalid piped objects are reported and skipped. If no valid endpoint IDs are supplied, the command does not call the API.</maml:para>
       <maml:para>Use -WhatIf to preview the operation. Use -Force to bypass confirmation prompts.</maml:para>
       <maml:para>The command uses the module default organization configured by Set-Action1DefaultOrg .</maml:para>
     </maml:description>
@@ -2902,6 +2935,130 @@ Update-Action1Endpoint -EndpointObject $endpoint -Comment 'Assigned to accountin
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-Action1EndpointGroupMembers</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>Specifies the ID of the endpoint group that receives the endpoints.</maml:para>
+            <maml:para>Endpoint group IDs are opaque strings, not GUIDs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+          <maml:name>EndpointObjects</maml:name>
+          <maml:description>
+            <maml:para>Specifies endpoint objects to add to the endpoint group. The command accepts these objects from the pipeline.</maml:para>
+            <maml:para>Each object must include an `id` property that contains a standard endpoint GUID. Invalid objects are reported and skipped.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Suppresses confirmation prompts. This parameter does not override -WhatIf .</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-Action1EndpointGroupMembers</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+          <maml:name>EndpointObjects</maml:name>
+          <maml:description>
+            <maml:para>Specifies endpoint objects to add to the endpoint group. The command accepts these objects from the pipeline.</maml:para>
+            <maml:para>Each object must include an `id` property that contains a standard endpoint GUID. Invalid objects are reported and skipped.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Suppresses confirmation prompts. This parameter does not override -WhatIf .</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of the endpoint group that receives the endpoints.</maml:para>
+            <maml:para>The command resolves the name by calling `Resolve-Action1EndpointGroupByName`. If the name is not found or is not unique, the command writes a terminating error.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
@@ -2925,6 +3082,19 @@ Update-Action1Endpoint -EndpointObject $endpoint -Comment 'Assigned to accountin
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
           <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <maml:name>EndpointObjects</maml:name>
+        <maml:description>
+          <maml:para>Specifies endpoint objects to add to the endpoint group. The command accepts these objects from the pipeline.</maml:para>
+          <maml:para>Each object must include an `id` property that contains a standard endpoint GUID. Invalid objects are reported and skipped.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -2983,10 +3153,10 @@ Update-Action1Endpoint -EndpointObject $endpoint -Comment 'Assigned to accountin
     <command:inputTypes>
       <command:inputType>
         <dev:type>
-          <maml:name>None</maml:name>
+          <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
-          <maml:para>You cannot pipe input to this command.</maml:para>
+          <maml:para>You can pipe endpoint objects with an `id` property to this command.</maml:para>
         </maml:description>
       </command:inputType>
     </command:inputTypes>
@@ -3034,7 +3204,30 @@ Add-Action1EndpointGroupMembers `
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>---------------- Example 3: Preview the request ----------------</maml:title>
+        <maml:title>----- Example 3: Add piped group members to another group -----</maml:title>
+        <dev:code>Get-Action1EndpointGroupMembers `
+    -GroupName 'Pilot Workstations' `
+    -Status Connected `
+    -RebootRequired No `
+    -OS 'Windows 11' |
+    Add-Action1EndpointGroupMembers -GroupName 'Production Workstations'</dev:code>
+        <dev:remarks>
+          <maml:para>Gets connected Windows 11 endpoints that do not require reboot from the Pilot Workstations endpoint group, collects their endpoint IDs, and adds them to the Production Workstations endpoint group with one API request.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Example 4: Add filtered endpoints from the organization endpoint list</maml:title>
+        <dev:code>Get-Action1Endpoints `
+    -Status Connected `
+    -RebootRequired Yes `
+    -OS 'Windows Server' |
+    Add-Action1EndpointGroupMembers -GroupName 'Servers Pending Reboot'</dev:code>
+        <dev:remarks>
+          <maml:para>Gets connected Windows Server endpoints that require reboot from the current organization and adds them to the Servers Pending Reboot endpoint group.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>---------------- Example 5: Preview the request ----------------</maml:title>
         <dev:code>Add-Action1EndpointGroupMembers `
     -GroupId 'Service_1696554367754' `
     -EndpointIds $endpointIds `
@@ -3055,6 +3248,10 @@ Add-Action1EndpointGroupMembers `
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Get-Action1EndpointGroupMembers</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Get-Action1Endpoints</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
@@ -4234,7 +4431,7 @@ Add-Action1EndpointGroupMembers `
           <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
-          <maml:para>Returns endpoint objects from Action1.</maml:para>
+          <maml:para>Returns endpoint objects from Action1. The objects include an `id` property and can be piped to Add-Action1EndpointGroupMembers or Remove-Action1EndpointGroupMembers .</maml:para>
         </maml:description>
       </command:returnValue>
     </command:returnValues>
@@ -4285,6 +4482,32 @@ Add-Action1EndpointGroupMembers `
           <maml:para>Gets endpoints from the endpoint group and selects key fields.</maml:para>
         </dev:remarks>
       </command:example>
+      <command:example>
+        <maml:title>Example 6: Add filtered group members to another endpoint group</maml:title>
+        <dev:code>Get-Action1EndpointGroupMembers `
+    -GroupName 'Pilot Workstations' `
+    -Status Connected `
+    -RebootRequired No `
+    -OS 'Windows 11' |
+    Add-Action1EndpointGroupMembers -GroupName 'Production Workstations'</dev:code>
+        <dev:remarks>
+          <maml:para>Gets connected Windows 11 endpoints that do not require reboot from the Pilot Workstations endpoint group, then pipes them to Add-Action1EndpointGroupMembers . The add command collects the endpoint IDs and sends one bulk API request.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>------ Example 7: Preview removing filtered group members ------</maml:title>
+        <dev:code>Get-Action1EndpointGroupMembers `
+    -GroupName 'Retired Workstations' `
+    -Status Disconnected `
+    -RebootRequired All `
+    -OS 'Windows 10' |
+    Remove-Action1EndpointGroupMembers `
+        -GroupName 'Retired Workstations' `
+        -WhatIf</dev:code>
+        <dev:remarks>
+          <maml:para>Gets disconnected Windows 10 endpoints from the Retired Workstations endpoint group, then previews removing those endpoints from the same group.</maml:para>
+        </dev:remarks>
+      </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
@@ -4297,6 +4520,14 @@ Add-Action1EndpointGroupMembers `
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Get-Action1Endpoints</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Add-Action1EndpointGroupMembers</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Remove-Action1EndpointGroupMembers</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
@@ -4387,6 +4618,7 @@ Add-Action1EndpointGroupMembers `
       <maml:para>Removes managed endpoints from a specific endpoint group by calling the Action1 endpoint group contents API once with one operation object per endpoint.</maml:para>
       <maml:para>The command accepts an endpoint group ID or an endpoint group name. When -GroupName is used, the command resolves the name by searching endpoint groups in the current organization and then calls the endpoint group contents API path with the resolved ID.</maml:para>
       <maml:para>Each -EndpointIds value must use the standard GUID format. The command sends an Action1 group-member operation for each endpoint ID with `method` set to `DELETE` and `endpoint_id` set to the supplied endpoint ID.</maml:para>
+      <maml:para>You can also pipe endpoint objects to the command. Piped endpoint objects must include an `id` property that contains the endpoint GUID. The command collects valid endpoint IDs from all pipeline input before sending a single API request. Invalid piped objects are reported and skipped. If no valid endpoint IDs are supplied, the command does not call the API.</maml:para>
       <maml:para>Use -WhatIf to preview the operation. Use -Force to bypass confirmation prompts.</maml:para>
       <maml:para>The command uses the module default organization configured by Set-Action1DefaultOrg .</maml:para>
     </maml:description>
@@ -4515,6 +4747,130 @@ Add-Action1EndpointGroupMembers `
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Remove-Action1EndpointGroupMembers</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>Specifies the ID of the endpoint group that contains the endpoints.</maml:para>
+            <maml:para>Endpoint group IDs are opaque strings, not GUIDs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+          <maml:name>EndpointObjects</maml:name>
+          <maml:description>
+            <maml:para>Specifies endpoint objects to remove from the endpoint group. The command accepts these objects from the pipeline.</maml:para>
+            <maml:para>Each object must include an `id` property that contains a standard endpoint GUID. Invalid objects are reported and skipped.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Suppresses confirmation prompts. This parameter does not override -WhatIf .</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Remove-Action1EndpointGroupMembers</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+          <maml:name>EndpointObjects</maml:name>
+          <maml:description>
+            <maml:para>Specifies endpoint objects to remove from the endpoint group. The command accepts these objects from the pipeline.</maml:para>
+            <maml:para>Each object must include an `id` property that contains a standard endpoint GUID. Invalid objects are reported and skipped.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Suppresses confirmation prompts. This parameter does not override -WhatIf .</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GroupName</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of the endpoint group that contains the endpoints.</maml:para>
+            <maml:para>The command resolves the name by calling `Resolve-Action1EndpointGroupByName`. If the name is not found or is not unique, the command writes a terminating error.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
@@ -4538,6 +4894,19 @@ Add-Action1EndpointGroupMembers `
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
           <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="none">
+        <maml:name>EndpointObjects</maml:name>
+        <maml:description>
+          <maml:para>Specifies endpoint objects to remove from the endpoint group. The command accepts these objects from the pipeline.</maml:para>
+          <maml:para>Each object must include an `id` property that contains a standard endpoint GUID. Invalid objects are reported and skipped.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4596,10 +4965,10 @@ Add-Action1EndpointGroupMembers `
     <command:inputTypes>
       <command:inputType>
         <dev:type>
-          <maml:name>None</maml:name>
+          <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
-          <maml:para>You cannot pipe input to this command.</maml:para>
+          <maml:para>You can pipe endpoint objects with an `id` property to this command.</maml:para>
         </maml:description>
       </command:inputType>
     </command:inputTypes>
@@ -4647,7 +5016,33 @@ Remove-Action1EndpointGroupMembers `
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>---------------- Example 3: Preview the request ----------------</maml:title>
+        <maml:title>--------- Example 3: Remove piped members from a group ---------</maml:title>
+        <dev:code>Get-Action1EndpointGroupMembers `
+    -GroupName 'Retired Workstations' `
+    -Status Disconnected `
+    -RebootRequired All `
+    -OS 'Windows 10' |
+    Remove-Action1EndpointGroupMembers -GroupName 'Retired Workstations'</dev:code>
+        <dev:remarks>
+          <maml:para>Gets disconnected Windows 10 endpoints from the Retired Workstations endpoint group, collects their endpoint IDs, and removes those endpoints from the same endpoint group with one API request.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>------ Example 4: Preview removing filtered group members ------</maml:title>
+        <dev:code>Get-Action1EndpointGroupMembers `
+    -GroupName 'Workstations' `
+    -Status Connected `
+    -RebootRequired Yes `
+    -OS 'Windows 11' |
+    Remove-Action1EndpointGroupMembers `
+        -GroupName 'Workstations' `
+        -WhatIf</dev:code>
+        <dev:remarks>
+          <maml:para>Gets connected Windows 11 endpoints that require reboot from the Workstations endpoint group, then previews removing those endpoints from the group.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>---------------- Example 5: Preview the request ----------------</maml:title>
         <dev:code>Remove-Action1EndpointGroupMembers `
     -GroupId 'Service_1696554367754' `
     -EndpointIds $endpointIds `
@@ -4672,6 +5067,10 @@ Remove-Action1EndpointGroupMembers `
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Get-Action1EndpointGroupMembers</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Get-Action1Endpoints</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>


### PR DESCRIPTION
Support Endpoint object pipelines in Add / Remove endpoint group members cmdlets


```powershell
Get-Action1Endpoints `
    -Status Connected `
    -RebootRequired Yes `
    -OS 'Windows Server' |
    Add-Action1EndpointGroupMembers -GroupName 'Servers Pending Reboot'
```

Gets connected Windows Server endpoints that require reboot from the current
organization and adds them to the Servers Pending Reboot endpoint group.


```powershell
Get-Action1EndpointGroupMembers `
    -GroupName 'Pilot Workstations' `
    -Status Connected `
    -RebootRequired No `
    -OS 'Windows 11' |
    Add-Action1EndpointGroupMembers -GroupName 'Production Workstations'
```

Gets connected Windows 11 endpoints that do not require reboot from the Pilot
Workstations endpoint group, then pipes them to
**Add-Action1EndpointGroupMembers**. The add command collects the endpoint IDs
and sends one bulk API request.